### PR TITLE
Forward the caller IP through MCP guest creates

### DIFF
--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -13,7 +13,7 @@ Stable nouns. Not a changelog.
 ## Invariants
 
 - Guest create works with no secrets other than rate-limit KV.
-- Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally.
+- Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. MCP `create_thread` forwards the caller IP so those limits apply per client, not to every unauthenticated MCP call as `unknown`.
 - Guest polls wait 5 seconds. Poll rate limits use Cache first and write KV at most every 30 seconds.
 - Shareable `/t/{id}/{viewToken}` is read-only. View polls are IP-limited at 5 seconds.
 - Actions `OAUTH_GITHUB_*` map to Worker `GITHUB_*` (Actions reserves `GITHUB_*`).

--- a/src/mcp.node.test.ts
+++ b/src/mcp.node.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'vitest'
+import { handleRequest } from '#src/index.ts'
+import { createTestEnv, request } from '#src/test-support.ts'
+
+function mcpCreate(ip: string, purpose: string) {
+	return request('/mcp', {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			'cf-connecting-ip': ip,
+		},
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: 'create_thread',
+				arguments: { purpose, name: 'cursor' },
+			},
+		}),
+	})
+}
+
+type McpToolRpc = {
+	result?: { content?: Array<{ text?: string }> }
+}
+
+function toolPayload(rpc: McpToolRpc) {
+	const text = rpc.result?.content?.[0]?.text
+	if (!text) throw new Error('MCP tool result had no text')
+	return JSON.parse(text) as { ok?: boolean; code?: string }
+}
+
+test('MCP guest creates honor the caller IP', async () => {
+	const env = createTestEnv()
+	const first = await handleRequest(mcpCreate('203.0.113.40', 'one'), env)
+	expect(first.status).toBe(200)
+	expect(toolPayload(await first.json())).toMatchObject({ ok: true })
+
+	const sameIp = await handleRequest(mcpCreate('203.0.113.40', 'two'), env)
+	expect(toolPayload(await sameIp.json())).toMatchObject({
+		code: 'guest_thread_limit',
+	})
+
+	const otherIp = await handleRequest(mcpCreate('198.51.100.40', 'three'), env)
+	expect(toolPayload(await otherIp.json())).toMatchObject({ ok: true })
+})

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,5 +1,6 @@
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
 import { handleApi, json } from '#src/api.ts'
+import { copyClientIpHeaders } from '#src/rate-limit.ts'
 
 type JsonRpc = {
 	jsonrpc?: string
@@ -154,6 +155,7 @@ async function callTool(request: Request, env: AppEnv, message: JsonRpc) {
 
 	const headers = new Headers({ 'content-type': 'application/json' })
 	if (authorization) headers.set('authorization', authorization)
+	copyClientIpHeaders(request.headers, headers)
 	const forwarded = new Request(`${base}${path}`, {
 		method,
 		headers,

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -172,3 +172,10 @@ export function clientIp(request: Request) {
 		'unknown'
 	)
 }
+
+export function copyClientIpHeaders(from: Headers, to: Headers) {
+	const connectingIp = from.get('cf-connecting-ip')
+	if (connectingIp) to.set('cf-connecting-ip', connectingIp)
+	const forwardedFor = from.get('x-forwarded-for')
+	if (forwardedFor) to.set('x-forwarded-for', forwardedFor)
+}


### PR DESCRIPTION
Bugbot on #2 (already merged): MCP `create_thread` rebuilt the inner `POST /v1/threads` without `cf-connecting-ip` / `x-forwarded-for`. Every unauthenticated MCP guest create resolved to IP `unknown`, so the one-live-guest-thread-per-IP rule applied globally.

## Fix

Copy the caller IP headers onto the inner request. Same IP still gets `guest_thread_limit`; a different IP can create.

## Tried locally

- `npm run validate` green (17 tests)
- New test: two MCP creates from 203.0.113.40, second is guest_thread_limit; 198.51.100.40 succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bug fix for guest rate-limit attribution with a focused integration test; no auth or data-model changes.
> 
> **Overview**
> Fixes a bug where MCP **`create_thread`** proxied to **`POST /v1/threads`** without **`cf-connecting-ip`** / **`x-forwarded-for`**, so **`clientIp`** resolved to **`unknown`** and guest limits (one live thread per IP, hourly create caps) effectively applied to all MCP guest creates as one bucket.
> 
> **`copyClientIpHeaders`** copies those headers from the incoming MCP request onto the inner API request in **`callTool`**. Architecture docs note that MCP guest creates must forward the caller IP.
> 
> Adds **`mcp.node.test.ts`**: same IP gets **`guest_thread_limit`** on a second create; a different IP can still create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f98f88a17a82c93d194421a5a860777580b716d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->