### PR TITLE
Add Orchestrate and Ship PR skills from Kody

### DIFF
--- a/.agents/skills/orchestrate/SKILL.md
+++ b/.agents/skills/orchestrate/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: orchestrate
+description: >
+  Orchestrate sub-agents for large tasks inside a single environment: plan,
+  delegate coding to cheap/fast models, parallelize the critical path, keep
+  reviews lean, and close every loop. Use when acting as an orchestrator or
+  writing a kickoff for one. Prefer implement when fan-out does not clearly
+  pay. For multi-environment fleets, use conduct instead.
+---
+
+# Orchestrate
+
+Fan out **sub-agents inside one environment** (shared checkout). For separate
+environments/PRs, use `conduct`.
+
+Two modes: **be** the orchestrator, or **spawn** one (smarter model) if you are
+optimized for cheap/fast execution.
+
+## Defaults (override only if the user says so)
+
+- **Prefer implement.** Fan out only when non-conflicting workstreams clearly
+  beat one implementer. Sequential slices → implement (or one implementer).
+- **No orchestration theater.** Ban review → recheck → final → CI-watch chains
+  per slice. **One** hard-to-reverse review before merge.
+- **One CI wait path** — parent `gh pr checks` _or_ a ci-watcher, not both.
+- **Targeted tests while iterating;** full validate before ready-for-review.
+- Close loops yourself — don't leave humans as the relay.
+
+## Role
+
+1. Plan, delegate, integrate, ship. Bulk-code only when fan-out costs more.
+2. Frontier model orchestrates; cheap/fast models implement (prefer Grok 4.5 /
+   `composer-2.5-fast` for mechanical work).
+3. Critical path first; parallelize non-conflicting files; serialize shared ones.
+4. **You do final QA.** Never declare done from sub-agent claims.
+
+## Fan-out (when it pays)
+
+- One implementer per independent vertical slice
+- Cheap sweeps (parity / perf / errors)
+- Audit → prioritized cleanup, then parallel cleanup agents
+- One independent "hard-to-reverse / security / perf holes" review before merge
+
+## Kickoff (when spawning an orchestrator)
+
+Keep it short: goals + constraints + out-of-scope; "you orchestrate, don't bulk
+code"; preferred implementer model; single-environment (not conduct); done =
+falsifiable. Point at this skill.

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ship-pr
+description: >
+  Babysit a PR: iterate with AI reviewers and CI until green, get it ready,
+  optionally squash-merge as Kody and watch the deploy, then send a Discord
+  summary. Medium risk waits for AI reviewer(s) and addresses valid feedback.
+  Use when a pull request needs to be shepherded to done.
+---
+
+# Ship PR
+
+## Risk → merge authority
+
+Self-assess; user policy overrides.
+
+**Kent's standing policy (2026-08-08):** auto-ship (squash-merge + verify deploy)
+once AI reviewer feedback is addressed and CI is green, unless **high** risk.
+High risk still parks ready-for-review unless merge authority was granted
+explicitly.
+
+- **Low** — green CI; nits ignorable; squash-merge when policy allows.
+- **Medium** — wait for AI reviewer(s); address **valid** feedback (ignore
+  insignificant nits / already-fixed / wrong); then merge when policy allows.
+- **High** — leave ready-for-review unless the user granted merge authority.
+
+## AI reviewers
+
+Prefer **Cursor Bugbot** (`Cursor Bugbot` check / `cursor[bot]` review comments).
+Trigger with `bugbot run` or `@cursor review` on the PR if it has not started.
+
+**CodeRabbit:** if it is rate-limited, errored, or otherwise unavailable, **do not
+wait** on it for low/medium risk — proceed with Bugbot + CI. Only wait on
+CodeRabbit when the change is **high** risk (or the user explicitly asks).
+
+## Loop
+
+1. Mark ready — `kody:@kentcdodds/github/pr/set-review-status`
+   `{ prUrl, status: 'ready' }` (or owner/repo/prNumber).
+2. Wait for CI — `gh pr checks` (or compose `loop-on-ci` / `fix-ci`).
+3. Fix failures; for **medium+**, wait on AI reviewer(s) (Bugbot first; see
+   above for CodeRabbit) and address valid feedback. Rebase only when actually
+   unmergeable.
+4. Green + (medium+: valid feedback cleared) → break.
+5. Push → repeat.
+
+## Gates ≠ CI
+
+Blocked on soak / parity CHECK / calendar gate → **end the run** and schedule a
+wake (Kody `job_schedule` + `createRun`). Don't sleep-poll or code-thrash an
+intentional time window.
+
+Batch related expand steps into fewer PRs when risk posture allows.
+
+## Merge / deploy
+
+When policy + risk allow: squash-merge via `kody:@kentcdodds/github/pr/merge`
+`{ prUrl, mergeMethod: 'squash' }`, watch deploy. Useful: `pr/get-checks`,
+`request`, `graphql` on the same package.
+
+## Done → Discord
+
+Always summarize (merged or not) with agent / PR / CI / deploy links:
+
+```javascript
+import postMessage from 'kody:@kentcdodds/discord/post-message'
+
+export default async function main() {
+	return postMessage({
+		channelId: '1491568683737157683',
+		content: '…summary with links…',
+	})
+}
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# kody.exchange agent index
+
+A spot for two or more agents to have a conversation over HTTP.
+
+`npm run validate` is the single authoritative local gate. Production deploys
+from `main` after Validate succeeds (`workflow_run`).
+
+This file is brief. Skills and docs:
+
+- Orchestrate (single-environment fan-out):
+  [`.agents/skills/orchestrate/SKILL.md`](./.agents/skills/orchestrate/SKILL.md)
+- Ship a PR (CI, reviewers, merge, Discord):
+  [`.agents/skills/ship-pr/SKILL.md`](./.agents/skills/ship-pr/SKILL.md)
+- Setup and secrets:
+  [`docs/contributing/setup.md`](./docs/contributing/setup.md)
+- Primitives and invariants:
+  [`docs/contributing/architecture/primitives.md`](./docs/contributing/architecture/primitives.md)
+- Agent HTTP/MCP use:
+  [`docs/use/index.md`](./docs/use/index.md)
+
+## This repo
+
+- Merge GitHub mutations as Kent (`account: 'kent'` on
+  `@kentcdodds/github`). kody-bot does not have admin here.
+- No PR preview deploys. After merge, watch the production Deploy workflow and
+  `GET https://kody.exchange/health` until `commit` matches the merge SHA.
+- Do not `wrangler secret put` by hand. Deploy syncs Actions secrets.
+- Guest is one live thread per IP. MCP `create_thread` must forward the caller
+  IP.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The JSON response includes `connect_prompt` (keep for your agent), `join_prompt`
 
 ## Docs
 
+- [Agent index](./AGENTS.md) (orchestrate + ship-pr skills)
 - [Primitives and invariants](./docs/contributing/architecture/primitives.md)
 - [Setup](./docs/contributing/setup.md)
 - [Agent use](./docs/use/index.md)

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -41,4 +41,5 @@ Worker, D1, KV, and R2 are all named `kody-exchange` / `kody-exchange-blobs`. Pu
 npm run validate
 ```
 
-That is the authoritative local gate (lint, types, unit tests).
+That is the authoritative local gate (lint, types, unit tests). Agent workflows
+live in [`AGENTS.md`](../../AGENTS.md) and `.agents/skills/`.


### PR DESCRIPTION
Copy the canonical **Orchestrate** and **Ship PR** skills from the Kody skills registry (`@kentcdodds/skills`) into this repo so cloud agents have them locally.

- `.agents/skills/orchestrate/SKILL.md`
- `.agents/skills/ship-pr/SKILL.md` (includes Kent's 2026-08-08 auto-ship policy + Bugbot-first reviewers)
- `AGENTS.md` index with kody.exchange-specific notes (merge as Kent, no preview deploys, healthcheck after Deploy)

`npm run validate` green. Docs/skills only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent skill files only; no runtime, auth, or deployment code changes.
> 
> **Overview**
> Adds **local copies** of the Kody **Orchestrate** and **Ship PR** skills under `.agents/skills/` so cloud agents can follow them without pulling `@kentcdodds/skills`. Ship PR includes Kent’s auto-ship policy (2026-08-08), Bugbot-first reviewers, and the CI/review/merge/Discord loop.
> 
> Introduces **`AGENTS.md`** as the agent entry point: links to those skills plus existing contributing/use docs, and **kody.exchange-specific** rules (merge as Kent, no preview deploys, post-merge health check, no manual `wrangler secret put`, guest thread IP forwarding).
> 
> **README** and **`docs/contributing/setup.md`** now point at `AGENTS.md` and `.agents/skills/` for agent workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f09e62948a87e91e8bce0c276a362178ac17893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->