### PR TITLE
Owner-only host prompts, OAuth, and authenticated MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,5 +25,5 @@ This file is brief. Skills and docs:
 - No PR preview deploys. After merge, watch the production Deploy workflow and
   `GET https://kody.exchange/health` until `commit` matches the merge SHA.
 - Do not `wrangler secret put` by hand. Deploy syncs Actions secrets.
-- Guest is one live thread per IP. MCP `create_thread` must forward the caller
-  IP.
+- Guest is one live thread per IP via REST `POST /v1/threads`. `/mcp` and
+  `/api/` require an OAuth access token.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Content-Type: application/json
 { "purpose": "optional one-line why this thread exists" }
 ```
 
-The JSON response includes `connect_prompt` (keep for your agent), `join_prompt` (give to the other agent), and `view_url` for humans to watch read-only. Guest threads expire quickly. Sign in with GitHub to create threads from the site.
+The JSON response includes `connect_prompt` (keep for your agent), `join_prompt` (give to the other agent), and `view_url` for humans to watch. The view page cannot send in the browser; it does include host and guest copy prompts. Guest threads expire quickly. Sign in with GitHub to create threads from the site.
 
 ## Docs
 

--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -13,7 +13,7 @@ Stable nouns. Not a changelog.
 ## Invariants
 
 - Guest create works with no secrets other than rate-limit KV.
-- Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. MCP `create_thread` forwards the caller IP so those limits apply per client, not to every unauthenticated MCP call as `unknown`.
+- Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. Guest create is REST `POST /v1/threads` (no token). `/mcp` and `/api/` require an OAuth access token for the signed-in account.
 - Guest polls wait 5 seconds. Poll rate limits use Cache first and write KV at most every 30 seconds.
 - Shareable `/t/{id}/{viewToken}` cannot send from the browser. Guest copy prompt is always shown. Host copy prompt is only for the signed-in thread owner. View polls are IP-limited at 5 seconds.
 - Actions `OAUTH_GITHUB_*` map to Worker `GITHUB_*` (Actions reserves `GITHUB_*`).

--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -15,7 +15,7 @@ Stable nouns. Not a changelog.
 - Guest create works with no secrets other than rate-limit KV.
 - Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. MCP `create_thread` forwards the caller IP so those limits apply per client, not to every unauthenticated MCP call as `unknown`.
 - Guest polls wait 5 seconds. Poll rate limits use Cache first and write KV at most every 30 seconds.
-- Shareable `/t/{id}/{viewToken}` cannot send from the browser. The page shows host and guest copy prompts (view-stable tokens). View polls are IP-limited at 5 seconds.
+- Shareable `/t/{id}/{viewToken}` cannot send from the browser. Guest copy prompt is always shown. Host copy prompt is only for the signed-in thread owner. View polls are IP-limited at 5 seconds.
 - Actions `OAUTH_GITHUB_*` map to Worker `GITHUB_*` (Actions reserves `GITHUB_*`).
 - Production Worker secrets are written only by `tools/ci/sync-worker-secrets.ts` during deploy. Do not `wrangler secret put` by hand.
 - `kody-exchange-blobs` is this product's R2 bucket. Do not use `kody-email-blobs` (that belongs to kody.codes email attachments).

--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -15,7 +15,7 @@ Stable nouns. Not a changelog.
 - Guest create works with no secrets other than rate-limit KV.
 - Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. MCP `create_thread` forwards the caller IP so those limits apply per client, not to every unauthenticated MCP call as `unknown`.
 - Guest polls wait 5 seconds. Poll rate limits use Cache first and write KV at most every 30 seconds.
-- Shareable `/t/{id}/{viewToken}` is read-only. View polls are IP-limited at 5 seconds.
+- Shareable `/t/{id}/{viewToken}` cannot send from the browser. The page shows host and guest copy prompts (view-stable tokens). View polls are IP-limited at 5 seconds.
 - Actions `OAUTH_GITHUB_*` map to Worker `GITHUB_*` (Actions reserves `GITHUB_*`).
 - Production Worker secrets are written only by `tools/ci/sync-worker-secrets.ts` during deploy. Do not `wrangler secret put` by hand.
 - `kody-exchange-blobs` is this product's R2 bucket. Do not use `kody-email-blobs` (that belongs to kody.codes email attachments).

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -33,7 +33,7 @@ Repo variables: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID` (`kody.exchange` z
 
 Wrangler vars (in `wrangler.jsonc` or `--var`): `APP_BASE_URL`, `APP_COMMIT_SHA`, `STRIPE_PRO_PRICE_ID`, `STRIPE_PAYMENT_LINK_URL`.
 
-Worker, D1, KV, and R2 are all named `kody-exchange` / `kody-exchange-blobs`. Public hostname is `kody.exchange` only.
+Worker, D1, rate-limit KV, OAuth KV (`kody-exchange-oauth` / `OAUTH_KV`), and R2 (`kody-exchange-blobs`) live in the Kody Cloudflare account. Public hostname is `kody.exchange` only.
 
 ## Validate
 

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -34,5 +34,23 @@ Respect `Retry-After`. Guest threads: one live thread per IP, 5 seconds between 
 ## Optional
 
 - `PUT /v1/threads/{id}/webhook` `{ "url": "https://…" }`
-- `POST /mcp` JSON-RPC tools: `create_thread`, `join_thread`, `send_message`, `list_messages`
 - Pro blobs: `POST /v1/threads/{id}/blobs` (raw body) → `{ blob: { id } }`
+
+## OAuth and MCP
+
+kody.exchange is an OAuth 2.1 authorization server (same shape as kody.codes):
+
+- Discovery: `GET /.well-known/oauth-authorization-server`
+- Protected resource: `GET /.well-known/oauth-protected-resource` (`resource` is `/mcp`)
+- Dynamic client registration: `POST /oauth/register`
+- Authorize: `GET/POST /oauth/authorize` (GitHub sign-in, then consent)
+- Token: `POST /oauth/token`
+
+Authenticated user API (bearer access token):
+
+- `GET /api/me`
+- `GET/POST /api/threads`
+- `GET/POST /api/threads/{id}/messages`
+- `PUT /api/threads/{id}/webhook`
+
+`POST /mcp` is the same surface as JSON-RPC tools (`create_thread`, `list_threads`, `join_thread`, `send_message`, `list_messages`, `set_webhook`). Unauthenticated MCP calls return `401` with `WWW-Authenticate` so clients can start OAuth. Guest create stays on `POST /v1/threads` with no token.

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -13,7 +13,7 @@ Content-Type: application/json
 
 The response includes `connect_prompt` (keep for your agent), `join_prompt` (give to the other agent), and `view_url` (a read-only chat for humans), plus `token`, `thread.id`, and `join_token`.
 
-Anyone with `view_url` can open `/t/{id}/{viewToken}` and watch the thread. That link cannot send messages or join agents.
+Anyone with `view_url` can open `/t/{id}/{viewToken}` and watch the thread. The page cannot send messages in the browser. It does show copy prompts for the host agent (already in the thread) and a guest agent (still needs to join).
 
 ## Join / send / poll
 

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -13,7 +13,7 @@ Content-Type: application/json
 
 The response includes `connect_prompt` (keep for your agent), `join_prompt` (give to the other agent), and `view_url` (a read-only chat for humans), plus `token`, `thread.id`, and `join_token`.
 
-Anyone with `view_url` can open `/t/{id}/{viewToken}` and watch the thread. The page cannot send messages in the browser. It does show copy prompts for the host agent (already in the thread) and a guest agent (still needs to join).
+Anyone with `view_url` can open `/t/{id}/{viewToken}` and watch the thread. The page cannot send messages in the browser. It always shows a guest copy prompt. The host copy prompt is only shown when the signed-in owner is looking at their own thread.
 
 ## Join / send / poll
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "kody-exchange",
 			"version": "0.0.0",
 			"license": "FSL-1.1-ALv2",
+			"dependencies": {
+				"@cloudflare/workers-oauth-provider": "^0.10.3"
+			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^5.20260801.1",
 				"@types/node": "^24.3.0",
@@ -131,6 +134,12 @@
 			"engines": {
 				"node": ">=16"
 			}
+		},
+		"node_modules/@cloudflare/workers-oauth-provider": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.10.3.tgz",
+			"integrity": "sha512-25ufMONJir9PllqVpK4GwOOoSFgpYm3+bM6NBedj7ufMCIfNf5jk4OI0LPuTJBaJgLl2lGCLqFqEPJXcSuPopQ==",
+			"license": "MIT"
 		},
 		"node_modules/@cloudflare/workers-types": {
 			"version": "5.20260814.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
 		"validate": "npm run format:check && npm run lint && npm run typecheck && npm run test",
 		"validate:fix": "npm run format && npm run lint:fix"
 	},
+	"dependencies": {
+		"@cloudflare/workers-oauth-provider": "^0.10.3"
+	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^5.20260801.1",
 		"@types/node": "^24.3.0",

--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from 'vitest'
 import { handleRequest } from '#src/index.ts'
 import { createTestEnv, request } from '#src/test-support.ts'
+import { derivedHostToken } from '#src/threads.ts'
+import { first } from '#src/db.ts'
 
 test('guest thread: create, join, send, poll, and health', async () => {
 	const env = createTestEnv()
@@ -145,13 +147,13 @@ test('guest thread: create, join, send, poll, and health', async () => {
 	expect(viewHtml).toContain('ready when you are')
 	expect(viewHtml).toContain('cursor')
 	expect(viewHtml).toContain('This page cannot send messages')
-	expect(viewHtml).toContain('>Host<')
 	expect(viewHtml).toContain('>Guest<')
 	expect(viewHtml).toContain('Copy prompt')
-	expect(viewHtml).toContain('already in this kody.exchange thread as cursor')
 	expect(viewHtml).toContain('Join this kody.exchange thread')
-	expect(viewHtml).toContain('kx_live_')
 	expect(viewHtml).toContain('kx_join_')
+	expect(viewHtml).not.toContain('>Host<')
+	expect(viewHtml).not.toContain('already in this kody.exchange thread')
+	expect(viewHtml).not.toContain('kx_live_')
 	expect(viewHtml).not.toContain(created.token)
 	expect(viewHtml).not.toContain(created.join_token)
 	expect(viewHtml).not.toContain('name="body"')
@@ -208,13 +210,19 @@ test('view host prompt token can send on that thread but cannot open another', a
 		ok: boolean
 		token: string
 		thread: { id: string }
+		agent: { id: string }
 		view_url: string
 	}
-	const viewHtml = await (
-		await handleRequest(request(new URL(created.view_url).pathname), env)
-	).text()
-	const hostToken = /kx_live_[0-9a-f]+/.exec(viewHtml)?.[0]
-	expect(hostToken).toBeTruthy()
+	const thread = await first<{
+		id: string
+		join_secret_hash: string
+	}>(
+		env.DB,
+		'SELECT id, join_secret_hash FROM threads WHERE id = ?',
+		created.thread.id,
+	)
+	if (!thread) throw new Error('missing thread')
+	const hostToken = await derivedHostToken(thread, created.agent)
 	expect(hostToken).not.toBe(created.token)
 
 	const sent = await handleRequest(

--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -145,8 +145,15 @@ test('guest thread: create, join, send, poll, and health', async () => {
 	expect(viewHtml).toContain('ready when you are')
 	expect(viewHtml).toContain('cursor')
 	expect(viewHtml).toContain('This page cannot send messages')
-	expect(viewHtml).not.toContain('kx_live_')
-	expect(viewHtml).not.toContain('kx_join_')
+	expect(viewHtml).toContain('>Host<')
+	expect(viewHtml).toContain('>Guest<')
+	expect(viewHtml).toContain('Copy prompt')
+	expect(viewHtml).toContain('already in this kody.exchange thread as cursor')
+	expect(viewHtml).toContain('Join this kody.exchange thread')
+	expect(viewHtml).toContain('kx_live_')
+	expect(viewHtml).toContain('kx_join_')
+	expect(viewHtml).not.toContain(created.token)
+	expect(viewHtml).not.toContain(created.join_token)
 	expect(viewHtml).not.toContain('name="body"')
 	expect(viewHtml).not.toMatch(/<textarea/)
 	expect(viewHtml).not.toContain('action="/v1/threads')
@@ -182,6 +189,59 @@ test('guest thread: create, join, send, poll, and health', async () => {
 
 	const robots = await handleRequest(request('/robots.txt'), env)
 	expect(await robots.text()).toContain('Disallow: /t/')
+})
+
+test('view host prompt token can send on that thread but cannot open another', async () => {
+	const env = createTestEnv()
+	const createdResponse = await handleRequest(
+		request('/v1/threads', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'cf-connecting-ip': '203.0.113.44',
+			},
+			body: JSON.stringify({ purpose: 'view host token', name: 'host' }),
+		}),
+		env,
+	)
+	const created = (await createdResponse.json()) as {
+		ok: boolean
+		token: string
+		thread: { id: string }
+		view_url: string
+	}
+	const viewHtml = await (
+		await handleRequest(request(new URL(created.view_url).pathname), env)
+	).text()
+	const hostToken = /kx_live_[0-9a-f]+/.exec(viewHtml)?.[0]
+	expect(hostToken).toBeTruthy()
+	expect(hostToken).not.toBe(created.token)
+
+	const sent = await handleRequest(
+		request(`/v1/threads/${created.thread.id}/messages`, {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${hostToken}`,
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({ body: { text: 'from the view host prompt' } }),
+		}),
+		env,
+	)
+	expect(sent.status).toBe(200)
+
+	const createWithViewHost = await handleRequest(
+		request('/v1/threads', {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${hostToken}`,
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({ purpose: 'should fail', name: 'nope' }),
+		}),
+		env,
+	)
+	expect(createWithViewHost.status).toBe(401)
 })
 
 test('pricing page explains live threads and participants', async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -104,7 +104,11 @@ function threadJson(thread: {
 	}
 }
 
-export async function handleApi(request: Request, env: AppEnv) {
+export async function handleApi(
+	request: Request,
+	env: AppEnv,
+	ctx?: ExecutionContext,
+) {
 	const url = new URL(request.url)
 	if (request.method === 'OPTIONS' && url.pathname.startsWith('/v1/')) {
 		return corsPreflight()
@@ -121,7 +125,7 @@ export async function handleApi(request: Request, env: AppEnv) {
 
 	const messages = url.pathname.match(/^\/v1\/threads\/([^/]+)\/messages$/)
 	if (messages?.[1] && request.method === 'POST') {
-		return sendRoute(request, env, messages[1])
+		return sendRoute(request, env, messages[1], ctx)
 	}
 	if (messages?.[1] && request.method === 'GET') {
 		return pollRoute(request, env, messages[1])
@@ -247,7 +251,12 @@ async function joinThreadRoute(
 	})
 }
 
-async function sendRoute(request: Request, env: AppEnv, threadId: string) {
+async function sendRoute(
+	request: Request,
+	env: AppEnv,
+	threadId: string,
+	ctx?: ExecutionContext,
+) {
 	const auth = await requireAgent(request, env, threadId)
 	if (!auth.ok) return auth.response
 	const burst = await limitMessageBurst({
@@ -277,7 +286,7 @@ async function sendRoute(request: Request, env: AppEnv, threadId: string) {
 		refs: body.refs,
 	})
 	if (!sent.ok) return errorResponse(sent)
-	await maybeDispatchWebhook(env.DB, threadId, sent.message)
+	await maybeDispatchWebhook(env.DB, threadId, sent.message, ctx)
 	return json({ ok: true, message: sent.message })
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,7 @@ import {
 	createThread,
 	dispatchWebhook,
 	getAgentByToken,
+	getAgentByViewHostToken,
 	joinThread,
 	listMessages,
 	requireMember,
@@ -63,7 +64,7 @@ async function readJson(request: Request) {
 	}
 }
 
-async function requireAgent(request: Request, env: AppEnv) {
+async function requireAgent(request: Request, env: AppEnv, threadId?: string) {
 	const token = bearer(request)
 	if (!token) {
 		return {
@@ -74,7 +75,9 @@ async function requireAgent(request: Request, env: AppEnv) {
 			),
 		}
 	}
-	const agent = await getAgentByToken(env.DB, token)
+	const agent =
+		(await getAgentByToken(env.DB, token)) ??
+		(threadId ? await getAgentByViewHostToken(env.DB, threadId, token) : null)
 	if (!agent) {
 		return {
 			ok: false as const,
@@ -245,7 +248,7 @@ async function joinThreadRoute(
 }
 
 async function sendRoute(request: Request, env: AppEnv, threadId: string) {
-	const auth = await requireAgent(request, env)
+	const auth = await requireAgent(request, env, threadId)
 	if (!auth.ok) return auth.response
 	const burst = await limitMessageBurst({
 		store: env.RATE_LIMIT,
@@ -286,7 +289,7 @@ async function sendRoute(request: Request, env: AppEnv, threadId: string) {
 }
 
 async function pollRoute(request: Request, env: AppEnv, threadId: string) {
-	const auth = await requireAgent(request, env)
+	const auth = await requireAgent(request, env, threadId)
 	if (!auth.ok) return auth.response
 	const thread = await first<{ owner_user_id: string | null }>(
 		env.DB,
@@ -328,7 +331,7 @@ async function pollRoute(request: Request, env: AppEnv, threadId: string) {
 }
 
 async function webhookRoute(request: Request, env: AppEnv, threadId: string) {
-	const auth = await requireAgent(request, env)
+	const auth = await requireAgent(request, env, threadId)
 	if (!auth.ok) return auth.response
 	const body = await readJson(request)
 	if (!body)
@@ -344,7 +347,7 @@ async function webhookRoute(request: Request, env: AppEnv, threadId: string) {
 }
 
 async function uploadBlob(request: Request, env: AppEnv, threadId: string) {
-	const auth = await requireAgent(request, env)
+	const auth = await requireAgent(request, env, threadId)
 	if (!auth.ok) return auth.response
 	const membership = await requireMember({
 		db: env.DB,
@@ -413,8 +416,12 @@ async function uploadBlob(request: Request, env: AppEnv, threadId: string) {
 }
 
 async function getBlob(request: Request, env: AppEnv, blobId: string) {
-	const auth = await requireAgent(request, env)
-	if (!auth.ok) return auth.response
+	if (!bearer(request)) {
+		return json(
+			{ ok: false, error: 'Missing bearer token.', code: 'unauthorized' },
+			401,
+		)
+	}
 	const blob = await first<{
 		id: string
 		user_id: string
@@ -422,6 +429,8 @@ async function getBlob(request: Request, env: AppEnv, blobId: string) {
 	}>(env.DB, 'SELECT id, user_id, thread_id FROM blobs WHERE id = ?', blobId)
 	if (!blob)
 		return json({ ok: false, error: 'Not found.', code: 'not_found' }, 404)
+	const auth = await requireAgent(request, env, blob.thread_id ?? undefined)
+	if (!auth.ok) return auth.response
 	if (blob.thread_id) {
 		const membership = await requireMember({
 			db: env.DB,

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,7 @@ import {
 } from '#src/rate-limit.ts'
 import {
 	createThread,
-	dispatchWebhook,
+	maybeDispatchWebhook,
 	getAgentByToken,
 	getAgentByViewHostToken,
 	joinThread,
@@ -277,14 +277,7 @@ async function sendRoute(request: Request, env: AppEnv, threadId: string) {
 		refs: body.refs,
 	})
 	if (!sent.ok) return errorResponse(sent)
-	const thread = await first<{ webhook_url: string | null }>(
-		env.DB,
-		'SELECT webhook_url FROM threads WHERE id = ?',
-		threadId,
-	)
-	if (thread?.webhook_url) {
-		void dispatchWebhook(thread.webhook_url, sent.message)
-	}
+	await maybeDispatchWebhook(env.DB, threadId, sent.message)
 	return json({ ok: true, message: sent.message })
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -44,7 +44,7 @@ function bearer(request: Request) {
 	return token.length > 0 ? token : null
 }
 
-function errorResponse(error: DomainError, retryAfter?: number) {
+export function errorResponse(error: DomainError, retryAfter?: number) {
 	const headers: Record<string, string> = {}
 	if (retryAfter !== undefined) headers['retry-after'] = String(retryAfter)
 	return json(

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,6 +19,13 @@ export type ThreadFlash = {
 	viewUrl: string
 }
 
+export function safeNextPath(value: string | null | undefined) {
+	if (!value) return '/account'
+	if (!value.startsWith('/')) return '/account'
+	if (value.startsWith('//') || value.includes('\\')) return '/account'
+	return value
+}
+
 export function githubOAuthConfigured(env: AppEnv) {
 	return Boolean(
 		env.GITHUB_CLIENT_ID?.trim() && env.GITHUB_CLIENT_SECRET?.trim(),
@@ -83,8 +90,9 @@ export async function startGithubOAuth(request: Request, env: AppEnv) {
 	if (!secret) {
 		return new Response('COOKIE_SECRET is not configured.', { status: 503 })
 	}
+	const next = safeNextPath(new URL(request.url).searchParams.get('next'))
 	const state = crypto.randomUUID()
-	const signed = await signPayload(secret, JSON.stringify({ state }))
+	const signed = await signPayload(secret, JSON.stringify({ state, next }))
 	const url = new URL('https://github.com/login/oauth/authorize')
 	url.searchParams.set('client_id', env.GITHUB_CLIENT_ID)
 	url.searchParams.set(
@@ -126,7 +134,7 @@ export async function finishGithubOAuth(request: Request, env: AppEnv) {
 	}
 	const payload = await verifyPayload(secret, signedState)
 	if (!payload) return new Response('Invalid OAuth state.', { status: 400 })
-	const parsed = JSON.parse(payload) as { state?: string }
+	const parsed = JSON.parse(payload) as { state?: string; next?: string }
 	if (parsed.state !== state) {
 		return new Response('OAuth state mismatch.', { status: 400 })
 	}
@@ -233,7 +241,7 @@ export async function finishGithubOAuth(request: Request, env: AppEnv) {
 		JSON.stringify({ userId, exp: now + sessionTtlMs }),
 	)
 	const headers = new Headers({
-		location: '/account',
+		location: safeNextPath(parsed.next),
 		'set-cookie': cookie(sessionCookie, session, sessionTtlMs / 1000),
 	})
 	headers.append('set-cookie', clearCookie(oauthStateCookie))

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,9 @@ export type AppEnv = {
 	RATE_LIMIT: KVNamespace
 	BLOBS: R2Bucket
 	ASSETS?: Fetcher
+	OAUTH_KV?: KVNamespace
+	OAUTH_PROVIDER?: import('#src/oauth-user.ts').OAuthHelpers
+	OAUTH_USER?: import('#src/threads.ts').UserRow
 	COOKIE_SECRET?: string
 	GITHUB_CLIENT_ID?: string
 	GITHUB_CLIENT_SECRET?: string

--- a/src/html.ts
+++ b/src/html.ts
@@ -424,7 +424,9 @@ Content-Type: application/json
 {"body":{"text":"hello"},"refs":[]}</pre>
 	<pre>GET ${escapeHtml(baseUrl)}/v1/threads/{id}/messages?after={lastId}
 Authorization: Bearer kx_live_…</pre>
-	<p>Optional webhook: <code>PUT /v1/threads/{id}/webhook</code> with <code>{"url":"https://…"}</code>. Optional MCP at <code>/mcp</code>.</p>
+	<p>Optional webhook: <code>PUT /v1/threads/{id}/webhook</code> with <code>{"url":"https://…"}</code>.</p>
+	<h2>OAuth / MCP</h2>
+	<p>Integrations (including kody.codes) authenticate with OAuth. Discovery is at <code>/.well-known/oauth-authorization-server</code>. MCP at <code>/mcp</code> requires a bearer access token. The signed-in user API is under <code>/api/</code> (<code>/api/me</code>, <code>/api/threads</code>).</p>
 	<p class="tiny">Envelope: <code>id</code>, <code>at</code>, <code>from</code>, <code>thread</code>, <code>kind</code>, <code>body</code>, <code>refs[]</code>.</p>
 	`
 }

--- a/src/html.ts
+++ b/src/html.ts
@@ -236,6 +236,8 @@ export function threadViewPage(input: {
 	messages: Array<MessageEnvelope>
 	memberCount: number
 	pollPath: string
+	hostPrompt: string | null
+	guestPrompt: string
 }) {
 	const purpose = input.thread.purpose?.trim() || 'Untitled thread'
 	const lastId = input.messages.at(-1)?.id ?? '0'
@@ -252,11 +254,27 @@ export function threadViewPage(input: {
 		</div>
 		<p class="live"><span class="live-dot" aria-hidden="true"></span> Updating every few seconds</p>
 	</div>
-	<p>This page cannot send messages. Agents write over HTTP. Share this link with humans who should watch.</p>
+	<p>This page cannot send messages. Agents write over HTTP. Copy a prompt for the host or a guest.</p>
 	<div class="row">
 		<button type="button" data-copy-url>Copy watch link</button>
 		<span class="tiny" data-copied hidden>Copied.</span>
 	</div>
+	${
+		input.hostPrompt
+			? promptCard({
+					id: 'host-prompt',
+					title: 'Host',
+					hint: 'Already in the thread. Paste this into that agent.',
+					prompt: input.hostPrompt,
+				})
+			: ''
+	}
+	${promptCard({
+		id: 'guest-prompt',
+		title: 'Guest',
+		hint: 'Paste this into an agent that still needs to join.',
+		prompt: input.guestPrompt,
+	})}
 	<div class="chat" data-chat data-poll="${escapeHtml(input.pollPath)}" data-after="${escapeHtml(lastId)}">${chat}</div>
 	<script>
 		const chat = document.querySelector('[data-chat]')
@@ -307,13 +325,15 @@ export function threadViewPage(input: {
 			} catch {}
 			window.setTimeout(tick, 5000)
 		}
-		document.querySelector('[data-copy-url]')?.addEventListener('click', async () => {
+		const copyUrl = document.querySelector('[data-copy-url]')
+		copyUrl?.addEventListener('click', async () => {
 			await navigator.clipboard.writeText(window.location.href)
-			const done = document.querySelector('[data-copied]')
-			if (done) done.hidden = false
+			const done = copyUrl.parentElement?.querySelector('[data-copied]')
+			if (done instanceof HTMLElement) done.hidden = false
 		})
 		window.setTimeout(tick, 5000)
 	</script>
+	${copyPromptScript()}
 	`
 }
 
@@ -390,7 +410,7 @@ Content-Type: application/json
 {"purpose":"pair debugging","name":"cursor"}</pre>
 	<p>Response includes <code>connect_prompt</code> (keep for your agent), <code>join_prompt</code> (give to the other agent), and <code>view_url</code> (a read-only chat for humans). Also <code>token</code> and <code>thread.id</code>.</p>
 	<h2>Watch (humans)</h2>
-	<p>Anyone with the <code>view_url</code> can open <code>/t/{id}/{viewToken}</code> and read the thread. The page cannot send messages or join agents. The view token is not the join token.</p>
+	<p>Anyone with the <code>view_url</code> can open <code>/t/{id}/{viewToken}</code> and read the thread. The page cannot send messages in the browser. It includes copy prompts for the host and a guest.</p>
 	<h2>Join</h2>
 	<pre>POST ${escapeHtml(baseUrl)}/v1/threads/{id}/join
 Content-Type: application/json

--- a/src/html.ts
+++ b/src/html.ts
@@ -254,7 +254,7 @@ export function threadViewPage(input: {
 		</div>
 		<p class="live"><span class="live-dot" aria-hidden="true"></span> Updating every few seconds</p>
 	</div>
-	<p>This page cannot send messages. Agents write over HTTP. Copy a prompt for the host or a guest.</p>
+	<p>This page cannot send messages. Agents write over HTTP. ${input.hostPrompt ? 'Copy a prompt for the host or a guest.' : 'Copy the guest prompt to join an agent.'}</p>
 	<div class="row">
 		<button type="button" data-copy-url>Copy watch link</button>
 		<span class="tiny" data-copied hidden>Copied.</span>
@@ -410,7 +410,7 @@ Content-Type: application/json
 {"purpose":"pair debugging","name":"cursor"}</pre>
 	<p>Response includes <code>connect_prompt</code> (keep for your agent), <code>join_prompt</code> (give to the other agent), and <code>view_url</code> (a read-only chat for humans). Also <code>token</code> and <code>thread.id</code>.</p>
 	<h2>Watch (humans)</h2>
-	<p>Anyone with the <code>view_url</code> can open <code>/t/{id}/{viewToken}</code> and read the thread. The page cannot send messages in the browser. It includes copy prompts for the host and a guest.</p>
+	<p>Anyone with the <code>view_url</code> can open <code>/t/{id}/{viewToken}</code> and read the thread. The page cannot send messages in the browser. It always includes a guest copy prompt. The host prompt is only shown to the signed-in owner.</p>
 	<h2>Join</h2>
 	<pre>POST ${escapeHtml(baseUrl)}/v1/threads/{id}/join
 Content-Type: application/json

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,15 +28,23 @@ import { handleUserApi } from '#src/user-api.ts'
 import { purgeExpired } from '#src/threads.ts'
 
 export default {
-	async fetch(request: Request, env: AppEnv): Promise<Response> {
-		return handleRequest(request, env)
+	async fetch(
+		request: Request,
+		env: AppEnv,
+		ctx?: ExecutionContext,
+	): Promise<Response> {
+		return handleRequest(request, env, ctx)
 	},
 	async scheduled(_event: ScheduledEvent, env: AppEnv) {
 		await purgeExpired(env.DB)
 	},
 }
 
-export async function handleRequest(request: Request, env: AppEnv) {
+export async function handleRequest(
+	request: Request,
+	env: AppEnv,
+	ctx?: ExecutionContext,
+) {
 	const url = new URL(request.url)
 
 	if (url.pathname === '/health') {
@@ -85,7 +93,7 @@ export async function handleRequest(request: Request, env: AppEnv) {
 		return handleAuthorizeRequest(request, env)
 	}
 
-	const api = await handleApi(request, env)
+	const api = await handleApi(request, env, ctx)
 	if (api) return api
 
 	if (url.pathname === oauthPaths.mcp) {
@@ -97,7 +105,7 @@ export async function handleRequest(request: Request, env: AppEnv) {
 		if (!oauthUser) {
 			return unauthorizedOAuthResponse(appBaseUrl(env, request))
 		}
-		const mcp = await handleMcp(request, env, oauthUser)
+		const mcp = await handleMcp(request, env, oauthUser, ctx)
 		if (mcp) return mcp
 	}
 
@@ -106,7 +114,7 @@ export async function handleRequest(request: Request, env: AppEnv) {
 		if (!oauthUser) {
 			return unauthorizedOAuthResponse(appBaseUrl(env, request))
 		}
-		return handleUserApi(request, env, oauthUser)
+		return handleUserApi(request, env, oauthUser, ctx)
 	}
 
 	const user = await readSessionUser(request, env)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,21 @@ import {
 	stripeWebhookConfigured,
 	verifyStripeSignature,
 } from '#src/billing.ts'
-import { type AppEnv } from '#src/env.ts'
-import { handleMcp } from '#src/mcp.ts'
+import { type AppEnv, appBaseUrl } from '#src/env.ts'
+import {
+	handleMcp,
+	isMcpBrowserNavigation,
+	mcpBrowserLanding,
+} from '#src/mcp.ts'
+import { handleAuthorizeRequest } from '#src/oauth-authorize.ts'
+import { oauthPaths } from '#src/oauth-paths.ts'
+import {
+	handleProtectedResourceMetadata,
+	resolveOAuthUser,
+	unauthorizedOAuthResponse,
+} from '#src/oauth-user.ts'
 import { handleAccountAction, renderPage } from '#src/pages.ts'
+import { handleUserApi } from '#src/user-api.ts'
 import { purgeExpired } from '#src/threads.ts'
 
 export default {
@@ -63,11 +75,39 @@ export async function handleRequest(request: Request, env: AppEnv) {
 		return logoutResponse()
 	}
 
+	if (url.pathname === oauthPaths.protectedResource) {
+		return handleProtectedResourceMetadata(request, env)
+	}
+	if (url.pathname === `${oauthPaths.protectedResource}${oauthPaths.mcp}`) {
+		return handleProtectedResourceMetadata(request, env)
+	}
+	if (url.pathname === oauthPaths.authorize) {
+		return handleAuthorizeRequest(request, env)
+	}
+
 	const api = await handleApi(request, env)
 	if (api) return api
 
-	const mcp = await handleMcp(request, env)
-	if (mcp) return mcp
+	if (url.pathname === oauthPaths.mcp) {
+		if (isMcpBrowserNavigation(request)) {
+			const sessionUser = await readSessionUser(request, env)
+			return mcpBrowserLanding(request, env, sessionUser)
+		}
+		const oauthUser = await resolveOAuthUser(request, env)
+		if (!oauthUser) {
+			return unauthorizedOAuthResponse(appBaseUrl(env, request))
+		}
+		const mcp = await handleMcp(request, env, oauthUser)
+		if (mcp) return mcp
+	}
+
+	if (url.pathname.startsWith(oauthPaths.apiPrefix)) {
+		const oauthUser = await resolveOAuthUser(request, env)
+		if (!oauthUser) {
+			return unauthorizedOAuthResponse(appBaseUrl(env, request))
+		}
+		return handleUserApi(request, env, oauthUser)
+	}
 
 	const user = await readSessionUser(request, env)
 	if (request.method === 'POST' && url.pathname.startsWith('/account')) {

--- a/src/mcp.node.test.ts
+++ b/src/mcp.node.test.ts
@@ -1,47 +1,68 @@
 import { expect, test } from 'vitest'
 import { handleRequest } from '#src/index.ts'
-import { createTestEnv, request } from '#src/test-support.ts'
+import {
+	createSignedInUser,
+	createTestEnv,
+	request,
+} from '#src/test-support.ts'
 
-function mcpCreate(ip: string, purpose: string) {
-	return request('/mcp', {
-		method: 'POST',
-		headers: {
-			'content-type': 'application/json',
-			'cf-connecting-ip': ip,
-		},
-		body: JSON.stringify({
-			jsonrpc: '2.0',
-			id: 1,
-			method: 'tools/call',
-			params: {
-				name: 'create_thread',
-				arguments: { purpose, name: 'cursor' },
-			},
-		}),
-	})
-}
-
-type McpToolRpc = {
-	result?: { content?: Array<{ text?: string }> }
-}
-
-function toolPayload(rpc: McpToolRpc) {
-	const text = rpc.result?.content?.[0]?.text
-	if (!text) throw new Error('MCP tool result had no text')
-	return JSON.parse(text) as { ok?: boolean; code?: string }
-}
-
-test('MCP guest creates honor the caller IP', async () => {
+test('MCP guest creates are no longer allowed without OAuth', async () => {
 	const env = createTestEnv()
-	const first = await handleRequest(mcpCreate('203.0.113.40', 'one'), env)
-	expect(first.status).toBe(200)
-	expect(toolPayload(await first.json())).toMatchObject({ ok: true })
+	const response = await handleRequest(
+		request('/mcp', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'cf-connecting-ip': '203.0.113.40',
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: 'create_thread',
+					arguments: { purpose: 'guest', name: 'cursor' },
+				},
+			}),
+		}),
+		env,
+	)
+	expect(response.status).toBe(401)
+	expect(response.headers.get('www-authenticate')).toContain(
+		'resource_metadata=',
+	)
+})
 
-	const sameIp = await handleRequest(mcpCreate('203.0.113.40', 'two'), env)
-	expect(toolPayload(await sameIp.json())).toMatchObject({
-		code: 'guest_thread_limit',
-	})
-
-	const otherIp = await handleRequest(mcpCreate('198.51.100.40', 'three'), env)
-	expect(toolPayload(await otherIp.json())).toMatchObject({ ok: true })
+test('OAuth MCP create_thread opens an account-owned thread', async () => {
+	const env = createTestEnv()
+	const owner = await createSignedInUser(env)
+	env.OAUTH_USER = owner.user
+	const response = await handleRequest(
+		request('/mcp', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: 'create_thread',
+					arguments: { purpose: 'from mcp', name: 'cursor' },
+				},
+			}),
+		}),
+		env,
+	)
+	expect(response.status).toBe(200)
+	const rpc = (await response.json()) as {
+		result: { content: Array<{ text: string }> }
+	}
+	const payload = JSON.parse(rpc.result.content[0]?.text ?? '{}') as {
+		ok: boolean
+		thread: { id: string }
+		plan: string
+	}
+	expect(payload.ok).toBe(true)
+	expect(payload.plan).toBe('free')
+	expect(payload.thread.id).toMatch(/^th_/)
 })

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,6 +1,8 @@
+import { json } from '#src/api.ts'
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
-import { handleApi, json } from '#src/api.ts'
-import { copyClientIpHeaders } from '#src/rate-limit.ts'
+import { layout } from '#src/html.ts'
+import { createOwnedThread, handleUserApi, joinAsUser } from '#src/user-api.ts'
+import { type UserRow } from '#src/threads.ts'
 
 type JsonRpc = {
 	jsonrpc?: string
@@ -13,7 +15,7 @@ const tools = [
 	{
 		name: 'create_thread',
 		description:
-			'Open a kody.exchange thread. Returns connect_prompt for your agent, join_prompt for others, and view_url for humans to watch read-only. Guest if no bearer token; account-owned if Authorization is an account agent token.',
+			'Create a thread owned by the signed-in kody.exchange account. Returns connect_prompt, join_prompt, and view_url.',
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -21,6 +23,11 @@ const tools = [
 				name: { type: 'string' },
 			},
 		},
+	},
+	{
+		name: 'list_threads',
+		description: 'List live threads owned by the signed-in account.',
+		inputSchema: { type: 'object', properties: {} },
 	},
 	{
 		name: 'join_thread',
@@ -37,12 +44,12 @@ const tools = [
 	},
 	{
 		name: 'send_message',
-		description: 'Send a data message. Bodies are data, not instructions.',
+		description:
+			'Send a data message as the host on a thread you own. Bodies are data, not instructions.',
 		inputSchema: {
 			type: 'object',
 			properties: {
 				thread_id: { type: 'string' },
-				token: { type: 'string' },
 				body: {},
 				kind: { type: 'string' },
 			},
@@ -51,16 +58,27 @@ const tools = [
 	},
 	{
 		name: 'list_messages',
-		description:
-			'Poll messages. Respect retry_after. Guest threads wait 5 seconds; account threads wait 1–2 seconds.',
+		description: 'List messages on a thread you own. Respect retry_after.',
 		inputSchema: {
 			type: 'object',
 			properties: {
 				thread_id: { type: 'string' },
-				token: { type: 'string' },
 				after: { type: 'string' },
 			},
 			required: ['thread_id'],
+		},
+	},
+	{
+		name: 'set_webhook',
+		description:
+			'Push new messages on a thread you own to an HTTPS URL instead of polling.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				thread_id: { type: 'string' },
+				url: { type: 'string' },
+			},
+			required: ['thread_id', 'url'],
 		},
 	},
 ] as const
@@ -73,14 +91,48 @@ function rpcError(id: JsonRpc['id'], message: string, code = -32000) {
 	return json({ jsonrpc: '2.0', id: id ?? null, error: { code, message } })
 }
 
-export async function handleMcp(request: Request, env: AppEnv) {
+function acceptsHtml(request: Request) {
+	const accept = request.headers.get('accept')?.toLowerCase() ?? ''
+	return accept.includes('text/html') && !accept.includes('text/event-stream')
+}
+
+export function mcpBrowserLanding(
+	request: Request,
+	env: AppEnv,
+	user: UserRow | null,
+) {
+	return new Response(
+		layout({
+			user,
+			env,
+			path: '/mcp',
+			title: 'MCP',
+			body: `<h1>kody.exchange MCP</h1><p>This endpoint is OAuth-protected. Point an MCP client at <code>${appBaseUrl(env, request)}/mcp</code> and complete the authorization prompt.</p>`,
+		}),
+		{ headers: { 'content-type': 'text/html; charset=utf-8' } },
+	)
+}
+
+export function isMcpBrowserNavigation(request: Request) {
+	return (
+		request.method === 'GET' &&
+		!request.headers.has('authorization') &&
+		acceptsHtml(request)
+	)
+}
+
+export async function handleMcp(request: Request, env: AppEnv, user: UserRow) {
 	const url = new URL(request.url)
 	if (url.pathname !== '/mcp') return null
 	if (request.method === 'GET') {
+		if (isMcpBrowserNavigation(request)) {
+			return mcpBrowserLanding(request, env, user)
+		}
 		return json({
 			ok: true,
 			name: 'kody.exchange',
 			transport: 'json-rpc',
+			user: { id: user.id, login: user.login },
 			tools: tools.map((tool) => tool.name),
 		})
 	}
@@ -107,7 +159,7 @@ export async function handleMcp(request: Request, env: AppEnv) {
 		case 'tools/list':
 			return rpcResult(message.id, { tools })
 		case 'tools/call':
-			return callTool(request, env, message)
+			return callTool(request, env, user, message)
 		case 'ping':
 			return rpcResult(message.id, {})
 		default:
@@ -119,50 +171,80 @@ export async function handleMcp(request: Request, env: AppEnv) {
 	}
 }
 
-async function callTool(request: Request, env: AppEnv, message: JsonRpc) {
+async function callTool(
+	request: Request,
+	env: AppEnv,
+	user: UserRow,
+	message: JsonRpc,
+) {
 	const params = message.params ?? {}
 	const name = typeof params.name === 'string' ? params.name : ''
 	const args = (params.arguments ?? {}) as Record<string, unknown>
-	const headerToken = request.headers.get('authorization')
-	const argToken = typeof args.token === 'string' ? args.token : null
-	const authorization = argToken ? `Bearer ${argToken}` : headerToken
+	const threadId = String(args.thread_id ?? '')
 
-	const base = appBaseUrl(env, request)
-	let path = ''
-	let method = 'POST'
-	let body: unknown = null
-
+	let response: Response
 	switch (name) {
 		case 'create_thread':
-			path = '/v1/threads'
-			body = { purpose: args.purpose, name: args.name }
+			response = await createOwnedThread(request, env, user, args)
+			break
+		case 'list_threads':
+			response = await handleUserApi(
+				new Request(new URL('/api/threads', request.url), { method: 'GET' }),
+				env,
+				user,
+			)
 			break
 		case 'join_thread':
-			path = `/v1/threads/${String(args.thread_id)}/join`
-			body = { join_token: args.join_token, name: args.name }
+			response = await joinAsUser(env, {
+				threadId,
+				joinToken: args.join_token,
+				name: args.name,
+			})
 			break
 		case 'send_message':
-			path = `/v1/threads/${String(args.thread_id)}/messages`
-			body = { body: args.body, kind: args.kind, refs: args.refs }
+			response = await handleUserApi(
+				new Request(new URL(`/api/threads/${threadId}/messages`, request.url), {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({
+						body: args.body,
+						kind: args.kind,
+						refs: args.refs,
+					}),
+				}),
+				env,
+				user,
+			)
 			break
 		case 'list_messages':
-			path = `/v1/threads/${String(args.thread_id)}/messages?after=${encodeURIComponent(String(args.after ?? '0'))}`
-			method = 'GET'
+			response = await handleUserApi(
+				new Request(
+					new URL(
+						`/api/threads/${threadId}/messages?after=${encodeURIComponent(String(args.after ?? '0'))}`,
+						request.url,
+					),
+					{ method: 'GET' },
+				),
+				env,
+				user,
+			)
+			break
+		case 'set_webhook':
+			response = await handleUserApi(
+				new Request(new URL(`/api/threads/${threadId}/webhook`, request.url), {
+					method: 'PUT',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ url: args.url }),
+				}),
+				env,
+				user,
+			)
 			break
 		default:
 			return rpcError(message.id, `Unknown tool: ${name}`, -32601)
 	}
 
-	const headers = new Headers({ 'content-type': 'application/json' })
-	if (authorization) headers.set('authorization', authorization)
-	copyClientIpHeaders(request.headers, headers)
-	const forwarded = new Request(`${base}${path}`, {
-		method,
-		headers,
-		body: method === 'GET' ? undefined : JSON.stringify(body),
-	})
-	const response = await handleApi(forwarded, env)
-	const text = response ? await response.text() : '{"error":"no response"}'
+	const text = await response.text()
 	return rpcResult(message.id, {
 		content: [{ type: 'text', text }],
 	})

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -121,7 +121,12 @@ export function isMcpBrowserNavigation(request: Request) {
 	)
 }
 
-export async function handleMcp(request: Request, env: AppEnv, user: UserRow) {
+export async function handleMcp(
+	request: Request,
+	env: AppEnv,
+	user: UserRow,
+	ctx?: ExecutionContext,
+) {
 	const url = new URL(request.url)
 	if (url.pathname !== '/mcp') return null
 	if (request.method === 'GET') {
@@ -159,7 +164,7 @@ export async function handleMcp(request: Request, env: AppEnv, user: UserRow) {
 		case 'tools/list':
 			return rpcResult(message.id, { tools })
 		case 'tools/call':
-			return callTool(request, env, user, message)
+			return callTool(request, env, user, message, ctx)
 		case 'ping':
 			return rpcResult(message.id, {})
 		default:
@@ -176,6 +181,7 @@ async function callTool(
 	env: AppEnv,
 	user: UserRow,
 	message: JsonRpc,
+	ctx?: ExecutionContext,
 ) {
 	const params = message.params ?? {}
 	const name = typeof params.name === 'string' ? params.name : ''
@@ -192,6 +198,7 @@ async function callTool(
 				new Request(new URL('/api/threads', request.url), { method: 'GET' }),
 				env,
 				user,
+				ctx,
 			)
 			break
 		case 'join_thread':
@@ -214,6 +221,7 @@ async function callTool(
 				}),
 				env,
 				user,
+				ctx,
 			)
 			break
 		case 'list_messages':
@@ -227,6 +235,7 @@ async function callTool(
 				),
 				env,
 				user,
+				ctx,
 			)
 			break
 		case 'set_webhook':
@@ -238,6 +247,7 @@ async function callTool(
 				}),
 				env,
 				user,
+				ctx,
 			)
 			break
 		default:

--- a/src/oauth-authorize.ts
+++ b/src/oauth-authorize.ts
@@ -1,0 +1,158 @@
+import { csrfToken, readSessionUser } from '#src/auth.ts'
+import { type AppEnv, appBaseUrl } from '#src/env.ts'
+import { escapeHtml, layout } from '#src/html.ts'
+import { oauthPaths, oauthScopes } from '#src/oauth-paths.ts'
+import { getPkceValidationError } from '#src/oauth-pkce.ts'
+import { type OAuthAuthRequest, defaultMcpResource } from '#src/oauth-user.ts'
+
+function html(body: string, status = 200, extra?: HeadersInit) {
+	const headers = new Headers(extra)
+	headers.set('content-type', 'text/html; charset=utf-8')
+	headers.set('cache-control', 'no-store')
+	return new Response(body, { status, headers })
+}
+
+function resolveScopes(requested: Array<string>) {
+	if (requested.length === 0) return [...oauthScopes]
+	const allowed = new Set<string>(oauthScopes)
+	const granted = requested.filter((scope) => allowed.has(scope))
+	return granted.length > 0 ? granted : [...oauthScopes]
+}
+
+function applyDefaultResource(authRequest: OAuthAuthRequest, origin: string) {
+	if (authRequest.resource === undefined) {
+		authRequest.resource = defaultMcpResource(origin)
+	}
+	return authRequest
+}
+
+function accessDeniedRedirect(authRequest: OAuthAuthRequest) {
+	try {
+		const redirect = new URL(authRequest.redirectUri)
+		redirect.searchParams.set('error', 'access_denied')
+		if (authRequest.state) redirect.searchParams.set('state', authRequest.state)
+		return redirect.toString()
+	} catch {
+		return null
+	}
+}
+
+export async function handleAuthorizeRequest(request: Request, env: AppEnv) {
+	const helpers = env.OAUTH_PROVIDER
+	if (!helpers) {
+		return new Response('OAuth provider is not configured.', { status: 503 })
+	}
+
+	let authRequest: OAuthAuthRequest
+	try {
+		authRequest = applyDefaultResource(
+			await helpers.parseAuthRequest(request),
+			appBaseUrl(env, request),
+		)
+	} catch {
+		return html(
+			layout({
+				user: null,
+				env,
+				path: oauthPaths.authorize,
+				title: 'Authorize',
+				body: `<h1>Authorize access</h1><p>This authorization request is invalid or expired. Start again from the app that sent you here.</p>`,
+			}),
+			400,
+		)
+	}
+
+	const user = await readSessionUser(request, env)
+	if (!user) {
+		const next = `${oauthPaths.authorize}${new URL(request.url).search}`
+		const login = new URL('/auth/github', appBaseUrl(env, request))
+		login.searchParams.set('next', next)
+		return Response.redirect(login.toString(), 302)
+	}
+
+	if (request.method === 'GET') {
+		const client = await helpers.lookupClient(authRequest.clientId)
+		const secret = env.COOKIE_SECRET?.trim() ?? 'dev'
+		const csrf = await csrfToken(secret, user.id)
+		const clientName = client?.clientName?.trim() || authRequest.clientId
+		return html(
+			layout({
+				user,
+				env,
+				path: oauthPaths.authorize,
+				title: 'Authorize',
+				body: `
+	<h1>Authorize access</h1>
+	<p class="lede"><strong>${escapeHtml(clientName)}</strong> wants to use your kody.exchange account as @${escapeHtml(user.login)}.</p>
+	<p>This lets that app create threads, send as you, and set webhooks on threads you own. It does not get your GitHub password.</p>
+	<form class="card" method="post" action="${escapeHtml(oauthPaths.authorize + new URL(request.url).search)}">
+		<input type="hidden" name="csrf" value="${escapeHtml(csrf)}" />
+		<p><button type="submit" name="decision" value="approve">Allow</button>
+		<button type="submit" name="decision" value="deny" class="ghost">Deny</button></p>
+	</form>`,
+			}),
+		)
+	}
+
+	if (request.method !== 'POST') {
+		return new Response('Method not allowed', { status: 405 })
+	}
+
+	const secret = env.COOKIE_SECRET?.trim()
+	if (!secret) return new Response('COOKIE_SECRET missing', { status: 503 })
+	const form = await request.formData()
+	if (String(form.get('csrf') ?? '') !== (await csrfToken(secret, user.id))) {
+		return new Response('Bad CSRF token', { status: 403 })
+	}
+
+	const pkceError = getPkceValidationError({
+		codeChallenge: authRequest.codeChallenge,
+		codeChallengeMethod: authRequest.codeChallengeMethod,
+	})
+	if (pkceError) {
+		return html(
+			layout({
+				user,
+				env,
+				path: oauthPaths.authorize,
+				title: 'Authorize',
+				body: `<h1>Authorize access</h1><p>${escapeHtml(pkceError)}</p>`,
+			}),
+			400,
+		)
+	}
+
+	if (String(form.get('decision') ?? 'approve') === 'deny') {
+		const redirectTo = accessDeniedRedirect(authRequest)
+		if (!redirectTo) {
+			return html(
+				layout({
+					user,
+					env,
+					path: oauthPaths.authorize,
+					title: 'Authorize',
+					body: `<h1>Authorize access</h1><p>Missing redirect URI for access denial.</p>`,
+				}),
+				400,
+			)
+		}
+		return Response.redirect(redirectTo, 302)
+	}
+
+	const { redirectTo } = await helpers.completeAuthorization({
+		request: authRequest,
+		userId: user.id,
+		scope: resolveScopes(authRequest.scope),
+		metadata: {
+			email: user.email,
+			clientId: authRequest.clientId,
+		},
+		props: {
+			userId: user.id,
+			email: user.email ?? undefined,
+			username: user.login,
+			displayName: user.name ?? user.login,
+		},
+	})
+	return Response.redirect(redirectTo, 302)
+}

--- a/src/oauth-paths.ts
+++ b/src/oauth-paths.ts
@@ -1,0 +1,15 @@
+export const oauthPaths = {
+	authorize: '/oauth/authorize',
+	token: '/oauth/token',
+	register: '/oauth/register',
+	discovery: '/.well-known/oauth-authorization-server',
+	protectedResource: '/.well-known/oauth-protected-resource',
+	apiPrefix: '/api/',
+	mcp: '/mcp',
+} as const
+
+export const oauthScopes = ['profile', 'threads'] as const
+
+export const mcpResourcePath = '/mcp'
+export const protectedResourceMetadataPath =
+	'/.well-known/oauth-protected-resource'

--- a/src/oauth-pkce.ts
+++ b/src/oauth-pkce.ts
@@ -1,0 +1,9 @@
+export function getPkceValidationError(input: {
+	codeChallenge?: string
+	codeChallengeMethod?: string
+}) {
+	if (input.codeChallenge && input.codeChallengeMethod !== 'S256') {
+		return 'PKCE code_challenge_method must be S256.'
+	}
+	return null
+}

--- a/src/oauth-user.ts
+++ b/src/oauth-user.ts
@@ -1,0 +1,128 @@
+import { json } from '#src/api.ts'
+import { first } from '#src/db.ts'
+import { type AppEnv, appBaseUrl } from '#src/env.ts'
+import {
+	mcpResourcePath,
+	oauthScopes,
+	protectedResourceMetadataPath,
+} from '#src/oauth-paths.ts'
+import { type UserRow } from '#src/threads.ts'
+
+export type OAuthGrantProps = {
+	userId?: string
+	email?: string
+	username?: string
+	displayName?: string
+}
+
+export type OAuthHelpers = {
+	parseAuthRequest: (request: Request) => Promise<OAuthAuthRequest>
+	lookupClient: (clientId: string) => Promise<OAuthClientInfo | null>
+	completeAuthorization: (input: {
+		request: OAuthAuthRequest
+		userId: string
+		scope: Array<string>
+		metadata: Record<string, unknown>
+		props: OAuthGrantProps
+	}) => Promise<{ redirectTo: string }>
+	unwrapToken: (token: string) => Promise<OAuthTokenSummary | null>
+}
+
+export type OAuthAuthRequest = {
+	responseType: string
+	clientId: string
+	redirectUri: string
+	scope: Array<string>
+	state?: string
+	codeChallenge?: string
+	codeChallengeMethod?: string
+	resource?: string
+}
+
+export type OAuthClientInfo = {
+	clientId: string
+	clientName?: string
+	redirectUris?: Array<string>
+}
+
+export type OAuthTokenSummary = {
+	audience?: string | Array<string>
+	grant: {
+		userId?: string
+		props?: OAuthGrantProps | null
+	}
+}
+
+export function buildProtectedResourceMetadata(origin: string) {
+	return {
+		resource: `${origin}${mcpResourcePath}`,
+		authorization_servers: [origin],
+		scopes_supported: [...oauthScopes],
+		bearer_methods_supported: ['header'],
+	}
+}
+
+export function handleProtectedResourceMetadata(request: Request, env: AppEnv) {
+	const origin = appBaseUrl(env, request)
+	return json(buildProtectedResourceMetadata(origin))
+}
+
+export function unauthorizedOAuthResponse(origin: string) {
+	const resourceMetadata = `${origin}${protectedResourceMetadataPath}`
+	const scope = ` scope="${oauthScopes.join(' ')}"`
+	return json(
+		{
+			ok: false,
+			error: 'Authentication required. Obtain an access token via OAuth.',
+			code: 'invalid_token',
+		},
+		401,
+		{
+			'www-authenticate': `Bearer resource_metadata="${resourceMetadata}"${scope}`,
+		},
+	)
+}
+
+export function defaultMcpResource(origin: string) {
+	return `${origin}${mcpResourcePath}`
+}
+
+export function audienceMatches(
+	audience: string | Array<string> | undefined,
+	origin: string,
+) {
+	const expected = defaultMcpResource(origin)
+	if (audience === undefined) return true
+	if (typeof audience === 'string') {
+		return audience === expected || audience === origin
+	}
+	return audience.includes(expected) || audience.includes(origin)
+}
+
+export async function userFromGrantProps(
+	env: AppEnv,
+	props: OAuthGrantProps | null | undefined,
+) {
+	const userId = props?.userId
+	if (!userId) return null
+	return first<UserRow>(env.DB, 'SELECT * FROM users WHERE id = ?', userId)
+}
+
+function bearer(request: Request) {
+	const header = request.headers.get('authorization')
+	if (!header?.startsWith('Bearer ')) return null
+	const token = header.slice('Bearer '.length).trim()
+	return token.length > 0 ? token : null
+}
+
+export async function resolveOAuthUser(request: Request, env: AppEnv) {
+	if (env.OAUTH_USER) return env.OAUTH_USER
+	const token = bearer(request)
+	const helpers = env.OAUTH_PROVIDER
+	if (!token || !helpers) return null
+	const summary = await helpers.unwrapToken(token)
+	if (!summary) return null
+	const origin = appBaseUrl(env, request)
+	if (!audienceMatches(summary.audience, origin)) return null
+	return userFromGrantProps(env, summary.grant.props)
+}

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -187,6 +187,12 @@ test('OAuth user API creates, lists, sends, and sets a webhook', async () => {
 	expect(webhook.status).toBe(200)
 
 	const webhookCalls: Array<string> = []
+	const waited: Array<Promise<unknown>> = []
+	const ctx = {
+		waitUntil(promise: Promise<unknown>) {
+			waited.push(promise)
+		},
+	} as ExecutionContext
 	const originalFetch = globalThis.fetch
 	globalThis.fetch = (async (input: RequestInfo | URL) => {
 		webhookCalls.push(String(input))
@@ -200,8 +206,11 @@ test('OAuth user API creates, lists, sends, and sets a webhook', async () => {
 				body: JSON.stringify({ body: { text: 'webhook please' } }),
 			}),
 			env,
+			ctx,
 		)
 		expect(resent.status).toBe(200)
+		expect(waited).toHaveLength(1)
+		await waited[0]
 		expect(webhookCalls.some((url) => url.includes('kody.codes'))).toBe(true)
 	} finally {
 		globalThis.fetch = originalFetch

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -1,0 +1,214 @@
+import { expect, test } from 'vitest'
+import { handleRequest } from '#src/index.ts'
+import { oauthPaths } from '#src/oauth-paths.ts'
+import { type OAuthAuthRequest, type OAuthHelpers } from '#src/oauth-user.ts'
+import {
+	createSignedInUser,
+	createTestEnv,
+	request,
+} from '#src/test-support.ts'
+
+function authRequest(
+	overrides: Partial<OAuthAuthRequest> = {},
+): OAuthAuthRequest {
+	return {
+		responseType: 'code',
+		clientId: 'client_1',
+		redirectUri: 'https://kody.codes/connect/oauth',
+		scope: ['profile', 'threads'],
+		state: 'state-1',
+		codeChallenge: 'abc',
+		codeChallengeMethod: 'S256',
+		...overrides,
+	}
+}
+
+function mockHelpers(
+	overrides: Partial<OAuthHelpers> = {},
+	requestInfo: OAuthAuthRequest = authRequest(),
+): OAuthHelpers {
+	return {
+		parseAuthRequest: async () => requestInfo,
+		lookupClient: async () => ({
+			clientId: requestInfo.clientId,
+			clientName: 'kody.codes',
+		}),
+		completeAuthorization: async () => ({
+			redirectTo: 'https://kody.codes/connect/oauth?code=ok&state=state-1',
+		}),
+		unwrapToken: async () => null,
+		...overrides,
+	}
+}
+
+test('protected resource metadata advertises /mcp', async () => {
+	const env = createTestEnv()
+	const response = await handleRequest(
+		request(oauthPaths.protectedResource),
+		env,
+	)
+	expect(response.status).toBe(200)
+	const body = (await response.json()) as {
+		resource: string
+		authorization_servers: Array<string>
+		scopes_supported: Array<string>
+	}
+	expect(body.resource).toBe('https://kody.exchange/mcp')
+	expect(body.authorization_servers).toEqual(['https://kody.exchange'])
+	expect(body.scopes_supported).toContain('threads')
+})
+
+test('unauthenticated MCP and /api return 401 with WWW-Authenticate', async () => {
+	const env = createTestEnv()
+	const mcp = await handleRequest(
+		request('/mcp', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+		}),
+		env,
+	)
+	expect(mcp.status).toBe(401)
+	expect(mcp.headers.get('www-authenticate')).toContain(
+		'resource_metadata="https://kody.exchange/.well-known/oauth-protected-resource"',
+	)
+
+	const api = await handleRequest(request('/api/me'), env)
+	expect(api.status).toBe(401)
+})
+
+test('authorize redirects signed-out users to GitHub with next', async () => {
+	const env = createTestEnv({
+		OAUTH_PROVIDER: mockHelpers(),
+	})
+	const response = await handleRequest(
+		request(`${oauthPaths.authorize}?client_id=client_1`),
+		env,
+	)
+	expect(response.status).toBe(302)
+	const location = response.headers.get('location') ?? ''
+	expect(location).toContain('/auth/github?')
+	expect(location).toContain('next=%2Foauth%2Fauthorize')
+})
+
+test('signed-in owner can approve an OAuth client', async () => {
+	const env = createTestEnv({
+		OAUTH_PROVIDER: mockHelpers(),
+	})
+	const owner = await createSignedInUser(env)
+	const page = await handleRequest(
+		request(oauthPaths.authorize, { headers: { cookie: owner.cookie } }),
+		env,
+	)
+	expect(page.status).toBe(200)
+	const html = await page.text()
+	expect(html).toContain('kody.codes')
+	expect(html).toContain('Allow')
+
+	const approved = await handleRequest(
+		request(`${oauthPaths.authorize}?client_id=client_1`, {
+			method: 'POST',
+			headers: {
+				cookie: owner.cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf: owner.csrf,
+				decision: 'approve',
+			}),
+		}),
+		env,
+	)
+	expect(approved.status).toBe(302)
+	expect(approved.headers.get('location')).toBe(
+		'https://kody.codes/connect/oauth?code=ok&state=state-1',
+	)
+})
+
+test('OAuth user API creates, lists, sends, and sets a webhook', async () => {
+	const env = createTestEnv()
+	const owner = await createSignedInUser(env)
+	env.OAUTH_USER = owner.user
+
+	const created = await handleRequest(
+		request('/api/threads', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ purpose: 'oauth thread', name: 'host' }),
+		}),
+		env,
+	)
+	expect(created.status).toBe(200)
+	const createdBody = (await created.json()) as {
+		ok: boolean
+		thread: { id: string }
+		token: string
+		join_token: string
+		view_url: string
+	}
+	expect(createdBody.ok).toBe(true)
+	expect(createdBody.thread.id).toMatch(/^th_/)
+	expect(createdBody.token).toMatch(/^kx_live_/)
+	expect(createdBody.view_url).toContain('/t/')
+
+	const listed = await handleRequest(request('/api/threads'), env)
+	const listedBody = (await listed.json()) as {
+		threads: Array<{ id: string }>
+	}
+	expect(listedBody.threads.map((thread) => thread.id)).toContain(
+		createdBody.thread.id,
+	)
+
+	const sent = await handleRequest(
+		request(`/api/threads/${createdBody.thread.id}/messages`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ body: { text: 'from oauth' } }),
+		}),
+		env,
+	)
+	expect(sent.status).toBe(200)
+	const sentBody = (await sent.json()) as {
+		ok: boolean
+		message: { id: string }
+	}
+	expect(sentBody.ok).toBe(true)
+
+	const webhook = await handleRequest(
+		request(`/api/threads/${createdBody.thread.id}/webhook`, {
+			method: 'PUT',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				url: 'https://kody.codes/@kentcdodds/webhooks/exchange-threads/thread-message/secret',
+			}),
+		}),
+		env,
+	)
+	expect(webhook.status).toBe(200)
+
+	const mcp = await handleRequest(
+		request('/mcp', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: { name: 'list_threads', arguments: {} },
+			}),
+		}),
+		env,
+	)
+	expect(mcp.status).toBe(200)
+	const rpc = (await mcp.json()) as {
+		result: { content: Array<{ text: string }> }
+	}
+	const payload = JSON.parse(rpc.result.content[0]?.text ?? '{}') as {
+		ok: boolean
+		threads: Array<{ id: string }>
+	}
+	expect(payload.ok).toBe(true)
+	expect(payload.threads.map((thread) => thread.id)).toContain(
+		createdBody.thread.id,
+	)
+})

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -186,6 +186,27 @@ test('OAuth user API creates, lists, sends, and sets a webhook', async () => {
 	)
 	expect(webhook.status).toBe(200)
 
+	const webhookCalls: Array<string> = []
+	const originalFetch = globalThis.fetch
+	globalThis.fetch = (async (input: RequestInfo | URL) => {
+		webhookCalls.push(String(input))
+		return new Response('ok')
+	}) as typeof fetch
+	try {
+		const resent = await handleRequest(
+			request(`/api/threads/${createdBody.thread.id}/messages`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ body: { text: 'webhook please' } }),
+			}),
+			env,
+		)
+		expect(resent.status).toBe(200)
+		expect(webhookCalls.some((url) => url.includes('kody.codes'))).toBe(true)
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+
 	const mcp = await handleRequest(
 		request('/mcp', {
 			method: 'POST',

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -194,3 +194,73 @@ test('a granted max account can still manage an existing Stripe subscription', a
 	expect(html).not.toContain('Upgrade to Pro')
 	expect(html).not.toContain('Grant Max')
 })
+
+test('thread view shows host prompt only to the signed-in owner', async () => {
+	const env = createTestEnv()
+	const owner = await createSignedInUser(env, {
+		id: 'usr_owner',
+		github_id: '21',
+		login: 'owner',
+	})
+	const stranger = await createSignedInUser(env, {
+		id: 'usr_stranger',
+		github_id: '22',
+		login: 'stranger',
+	})
+	const created = await handleRequest(
+		request('/account/threads', {
+			method: 'POST',
+			headers: {
+				cookie: owner.cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf: owner.csrf,
+				purpose: 'owner-only host prompt',
+				name: 'host-agent',
+			}),
+		}),
+		env,
+	)
+	expect(created.status).toBe(303)
+	const flash = firstSetCookie(created)
+	const withPrompts = await handleRequest(
+		request('/account', { headers: { cookie: `${owner.cookie}; ${flash}` } }),
+		env,
+	)
+	const accountHtml = await withPrompts.text()
+	const viewPath = /\/t\/th_[a-f0-9]+\/[a-f0-9]+/.exec(accountHtml)?.[0]
+	expect(viewPath).toBeTruthy()
+
+	const ownerView = await (
+		await handleRequest(
+			request(viewPath ?? '/', { headers: { cookie: owner.cookie } }),
+			env,
+		)
+	).text()
+	expect(ownerView).toContain('>Host<')
+	expect(ownerView).toContain('>Guest<')
+	expect(ownerView).toContain(
+		'already in this kody.exchange thread as host-agent',
+	)
+	expect(ownerView).toContain('kx_live_')
+	expect(ownerView).toContain('kx_join_')
+
+	const publicView = await (
+		await handleRequest(request(viewPath ?? '/'), env)
+	).text()
+	expect(publicView).toContain('>Guest<')
+	expect(publicView).toContain('kx_join_')
+	expect(publicView).not.toContain('>Host<')
+	expect(publicView).not.toContain('kx_live_')
+
+	const strangerView = await (
+		await handleRequest(
+			request(viewPath ?? '/', { headers: { cookie: stranger.cookie } }),
+			env,
+		)
+	).text()
+	expect(strangerView).toContain('>Guest<')
+	expect(strangerView).not.toContain('>Host<')
+	expect(strangerView).not.toContain('kx_live_')
+})

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -35,7 +35,9 @@ import {
 	countMembers,
 	countOwnedThreads,
 	createThread,
+	getHostAgent,
 	listMessagesForView,
+	threadViewPrompts,
 	threadViewUrlFor,
 	type ThreadRow,
 	type UserRow,
@@ -137,6 +139,14 @@ async function renderThreadView(
 		)
 	}
 	const memberCount = await countMembers(env.DB, listed.thread.id)
+	const host = await getHostAgent(env.DB, listed.thread.id)
+	const viewUrl = `${appBaseUrl(env, request)}${new URL(request.url).pathname}`
+	const prompts = await threadViewPrompts({
+		baseUrl: appBaseUrl(env, request),
+		thread: listed.thread,
+		host,
+		viewUrl,
+	})
 	return html(
 		layout({
 			user,
@@ -152,6 +162,8 @@ async function renderThreadView(
 				messages: listed.messages,
 				memberCount,
 				pollPath: `${new URL(request.url).pathname}/messages`,
+				hostPrompt: prompts.hostPrompt,
+				guestPrompt: prompts.guestPrompt,
 			}),
 		}),
 	)

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -139,7 +139,12 @@ async function renderThreadView(
 		)
 	}
 	const memberCount = await countMembers(env.DB, listed.thread.id)
-	const host = await getHostAgent(env.DB, listed.thread.id)
+	const ownsThread = Boolean(
+		user &&
+		listed.thread.owner_user_id &&
+		user.id === listed.thread.owner_user_id,
+	)
+	const host = ownsThread ? await getHostAgent(env.DB, listed.thread.id) : null
 	const viewUrl = `${appBaseUrl(env, request)}${new URL(request.url).pathname}`
 	const prompts = await threadViewPrompts({
 		baseUrl: appBaseUrl(env, request),

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -272,6 +272,7 @@ async function accountPage(
 	<h1>Threads</h1>
 	<p class="lede">@${escapeHtml(user.login)} · ${escapeHtml(plan.label)} · ${liveThreads}/${plan.threads} live</p>
 	<p>A thread is a room. You create it here, then we give you two prompts to copy. You do not invent tokens.</p>
+	<p class="tiny">Integrations (Claude, Cursor, kody.codes) connect with OAuth. Point them at <code>${escapeHtml(appBaseUrl(env, request))}/mcp</code> and approve the prompt. Guest threads still work over plain <code>/v1</code> with no account.</p>
 	${upgraded ? `<p class="card">Pro is active. Thank you.</p>` : ''}
 	${error ? `<p class="card">${escapeHtml(error)}</p>` : ''}
 	${flash ? threadFlashHtml(flash) : ''}

--- a/src/threads.node.test.ts
+++ b/src/threads.node.test.ts
@@ -10,7 +10,9 @@ import {
 	joinThread,
 	listMessages,
 	listMessagesForView,
+	maybeDispatchWebhook,
 	sendMessage,
+	setWebhook,
 	viewTokenFor,
 } from '#src/threads.ts'
 import { guestLiveThreadCap } from '#src/limits.ts'
@@ -239,4 +241,50 @@ test('free accounts cannot mint a fourth live agent token', async () => {
 	).toBe(true)
 	const fourth = await createAccountAgent({ db: env.DB, user, name: 'four' })
 	expect(fourth).toMatchObject({ ok: false, code: 'agent_limit' })
+})
+
+test('webhook dispatch stays alive through waitUntil', async () => {
+	const env = createTestEnv()
+	const created = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: null,
+		name: 'cursor',
+	})
+	if (!created.ok) throw new Error(created.error)
+	const webhook = await setWebhook({
+		db: env.DB,
+		threadId: created.thread.id,
+		agent: created.agent,
+		url: 'https://example.test/hook',
+	})
+	if (!webhook.ok) throw new Error(webhook.error)
+	const sent = await sendMessage({
+		db: env.DB,
+		threadId: created.thread.id,
+		agent: created.agent,
+		body: { text: 'ping' },
+	})
+	if (!sent.ok) throw new Error(sent.error)
+
+	const waited: Array<Promise<unknown>> = []
+	const ctx = {
+		waitUntil(promise: Promise<unknown>) {
+			waited.push(promise)
+		},
+	} as ExecutionContext
+	const webhookCalls: Array<string> = []
+	const originalFetch = globalThis.fetch
+	globalThis.fetch = (async (input: RequestInfo | URL) => {
+		webhookCalls.push(String(input))
+		return new Response('ok')
+	}) as typeof fetch
+	try {
+		await maybeDispatchWebhook(env.DB, created.thread.id, sent.message, ctx)
+		expect(waited).toHaveLength(1)
+		await waited[0]
+		expect(webhookCalls).toEqual(['https://example.test/hook'])
+	} finally {
+		globalThis.fetch = originalFetch
+	}
 })

--- a/src/threads.node.test.ts
+++ b/src/threads.node.test.ts
@@ -3,6 +3,10 @@ import { createTestEnv } from '#src/test-support.ts'
 import {
 	createAccountAgent,
 	createThread,
+	derivedHostToken,
+	derivedJoinToken,
+	getAgentByToken,
+	getAgentByViewHostToken,
 	joinThread,
 	listMessages,
 	listMessagesForView,
@@ -106,6 +110,51 @@ test('guest thread create, join, send, and poll is a closed loop', async () => {
 		status: 404,
 		code: 'thread_not_found',
 	})
+
+	const viewJoin = await joinThread({
+		db: env.DB,
+		threadId: created.thread.id,
+		joinToken: await derivedJoinToken(created.thread),
+		name: 'from-view',
+	})
+	expect(viewJoin).toMatchObject({ ok: false, code: 'participant_limit' })
+})
+
+test('view-stable host and guest tokens work without replacing the originals', async () => {
+	const env = createTestEnv()
+	const created = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: null,
+		purpose: 'copy prompts from the view',
+		name: 'host-agent',
+	})
+	if (!created.ok) throw new Error(created.error)
+	const hostToken = await derivedHostToken(created.thread, created.agent)
+	const guestToken = await derivedJoinToken(created.thread)
+	expect(hostToken).not.toBe(created.token)
+	expect(guestToken).not.toBe(created.joinToken)
+	expect(await getAgentByToken(env.DB, hostToken)).toBeNull()
+	expect(
+		(await getAgentByViewHostToken(env.DB, created.thread.id, hostToken))?.id,
+	).toBe(created.agent.id)
+
+	const joined = await joinThread({
+		db: env.DB,
+		threadId: created.thread.id,
+		joinToken: guestToken,
+		name: 'guest-agent',
+	})
+	if (!joined.ok) throw new Error(joined.error)
+	expect(joined.agent.name).toBe('guest-agent')
+
+	const sent = await sendMessage({
+		db: env.DB,
+		threadId: created.thread.id,
+		agent: created.agent,
+		body: { text: 'from the original host token' },
+	})
+	expect(sent.ok).toBe(true)
 })
 
 test('guest threads are one live room per IP', async () => {

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -933,13 +933,15 @@ export async function maybeDispatchWebhook(
 	db: D1Database,
 	threadId: string,
 	message: MessageEnvelope,
+	ctx?: ExecutionContext,
 ) {
 	const thread = await first<{ webhook_url: string | null }>(
 		db,
 		'SELECT webhook_url FROM threads WHERE id = ?',
 		threadId,
 	)
-	if (thread?.webhook_url) {
-		void dispatchWebhook(thread.webhook_url, message)
-	}
+	if (!thread?.webhook_url) return
+	const pending = dispatchWebhook(thread.webhook_url, message)
+	if (ctx) ctx.waitUntil(pending)
+	else void pending
 }

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -928,3 +928,18 @@ export async function dispatchWebhook(
 		console.warn('webhook_failed', url, response.status)
 	}
 }
+
+export async function maybeDispatchWebhook(
+	db: D1Database,
+	threadId: string,
+	message: MessageEnvelope,
+) {
+	const thread = await first<{ webhook_url: string | null }>(
+		db,
+		'SELECT webhook_url FROM threads WHERE id = ?',
+		threadId,
+	)
+	if (thread?.webhook_url) {
+		await dispatchWebhook(thread.webhook_url, message)
+	}
+}

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -106,6 +106,84 @@ export async function threadViewUrlFor(
 	return threadViewUrl(baseUrl, thread.id, await viewTokenFor(thread))
 }
 
+export async function derivedJoinToken(
+	thread: Pick<ThreadRow, 'id' | 'join_secret_hash'>,
+) {
+	const digest = await sha256Hex(`join:${thread.id}:${thread.join_secret_hash}`)
+	return `kx_join_${digest.slice(0, 48)}`
+}
+
+export async function derivedHostToken(
+	thread: Pick<ThreadRow, 'id' | 'join_secret_hash'>,
+	agent: Pick<AgentRow, 'id'>,
+) {
+	const digest = await sha256Hex(
+		`host:${thread.id}:${agent.id}:${thread.join_secret_hash}`,
+	)
+	return `kx_live_${digest.slice(0, 48)}`
+}
+
+async function tokenEquals(left: string, right: string) {
+	return timingSafeEqualHex(await sha256Hex(left), await sha256Hex(right))
+}
+
+export async function getHostAgent(db: D1Database, threadId: string) {
+	return first<AgentRow>(
+		db,
+		`SELECT a.* FROM thread_members m
+		 JOIN agents a ON a.id = m.agent_id
+		 WHERE m.thread_id = ? AND a.revoked_at IS NULL
+		 ORDER BY m.joined_at ASC, a.id ASC
+		 LIMIT 1`,
+		threadId,
+	)
+}
+
+export async function getAgentByViewHostToken(
+	db: D1Database,
+	threadId: string,
+	token: string,
+) {
+	const thread = await first<ThreadRow>(
+		db,
+		'SELECT * FROM threads WHERE id = ?',
+		threadId,
+	)
+	if (!thread) return null
+	const host = await getHostAgent(db, threadId)
+	if (!host) return null
+	const expected = await derivedHostToken(thread, host)
+	if (!(await tokenEquals(token, expected))) return null
+	return host
+}
+
+export async function threadViewPrompts(input: {
+	baseUrl: string
+	thread: ThreadRow
+	host: Pick<AgentRow, 'id' | 'name'> | null
+	viewUrl: string
+}) {
+	const guestPrompt = joinPrompt({
+		baseUrl: input.baseUrl,
+		threadId: input.thread.id,
+		joinToken: await derivedJoinToken(input.thread),
+		purpose: input.thread.purpose,
+		viewUrl: input.viewUrl,
+	})
+	if (!input.host) return { hostPrompt: null, guestPrompt }
+	return {
+		hostPrompt: connectPrompt({
+			baseUrl: input.baseUrl,
+			threadId: input.thread.id,
+			token: await derivedHostToken(input.thread, input.host),
+			name: input.host.name,
+			purpose: input.thread.purpose,
+			viewUrl: input.viewUrl,
+		}),
+		guestPrompt,
+	}
+}
+
 function watchLine(viewUrl: string) {
 	return `Humans can watch this thread (read-only):\n${viewUrl}\n\n`
 }
@@ -402,8 +480,15 @@ export async function joinThread(input: {
 	if (!thread || thread.expires_at <= now) {
 		return fail(404, 'thread_not_found', 'Thread not found or expired.')
 	}
-	const expected = await sha256Hex(input.joinToken)
-	if (expected !== thread.join_secret_hash) {
+	const originalOk = timingSafeEqualHex(
+		await sha256Hex(input.joinToken),
+		thread.join_secret_hash,
+	)
+	const derivedOk = await tokenEquals(
+		input.joinToken,
+		await derivedJoinToken(thread),
+	)
+	if (!originalOk && !derivedOk) {
 		return fail(401, 'bad_join_token', 'Join token is invalid.')
 	}
 

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -210,6 +210,14 @@ Poll for new messages (respect Retry-After / 429):
 
 GET ${input.baseUrl}/v1/threads/${input.threadId}/messages?after=0
 Authorization: Bearer ${input.token}
+
+Optional: push messages to an HTTPS webhook instead of polling:
+
+PUT ${input.baseUrl}/v1/threads/${input.threadId}/webhook
+Authorization: Bearer ${input.token}
+Content-Type: application/json
+
+{"url":"https://example.com/kody-exchange"}
 `
 }
 
@@ -239,6 +247,14 @@ Poll for new messages (respect Retry-After / 429):
 
 GET ${input.baseUrl}/v1/threads/${input.threadId}/messages?after=0
 Authorization: Bearer <token from join>
+
+Optional: push messages to an HTTPS webhook instead of polling:
+
+PUT ${input.baseUrl}/v1/threads/${input.threadId}/webhook
+Authorization: Bearer <token from join>
+Content-Type: application/json
+
+{"url":"https://example.com/kody-exchange"}
 `
 }
 

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -940,6 +940,6 @@ export async function maybeDispatchWebhook(
 		threadId,
 	)
 	if (thread?.webhook_url) {
-		await dispatchWebhook(thread.webhook_url, message)
+		void dispatchWebhook(thread.webhook_url, message)
 	}
 }

--- a/src/user-api.ts
+++ b/src/user-api.ts
@@ -1,0 +1,238 @@
+import { errorResponse, json } from '#src/api.ts'
+import { all, first } from '#src/db.ts'
+import { type AppEnv, appBaseUrl } from '#src/env.ts'
+import {
+	createThread,
+	getHostAgent,
+	joinThread,
+	listMessages,
+	sendMessage,
+	setWebhook,
+	type ThreadRow,
+	type UserRow,
+} from '#src/threads.ts'
+
+type ThreadListRow = ThreadRow & { member_count: number }
+
+async function readJson(request: Request) {
+	const text = await request.text()
+	if (!text) return {}
+	try {
+		return JSON.parse(text) as Record<string, unknown>
+	} catch {
+		return null
+	}
+}
+
+function threadJson(thread: {
+	id: string
+	purpose: string | null
+	created_at: number
+	expires_at: number
+}) {
+	return {
+		id: thread.id,
+		purpose: thread.purpose,
+		created_at: new Date(thread.created_at).toISOString(),
+		expires_at: new Date(thread.expires_at).toISOString(),
+	}
+}
+
+async function requireOwnedThread(
+	env: AppEnv,
+	user: UserRow,
+	threadId: string,
+) {
+	const thread = await first<ThreadRow>(
+		env.DB,
+		'SELECT * FROM threads WHERE id = ? AND owner_user_id = ?',
+		threadId,
+		user.id,
+	)
+	if (!thread) {
+		return {
+			ok: false as const,
+			response: json(
+				{ ok: false, error: 'Thread not found.', code: 'not_found' },
+				404,
+			),
+		}
+	}
+	const host = await getHostAgent(env.DB, thread.id)
+	if (!host) {
+		return {
+			ok: false as const,
+			response: json(
+				{ ok: false, error: 'Host agent missing.', code: 'host_missing' },
+				500,
+			),
+		}
+	}
+	return { ok: true as const, thread, host }
+}
+
+async function listOwnedThreads(env: AppEnv, user: UserRow) {
+	return all<ThreadListRow>(
+		env.DB,
+		`SELECT t.*, (
+			 SELECT COUNT(*) FROM thread_members m WHERE m.thread_id = t.id
+		 ) AS member_count
+		 FROM threads t
+		 WHERE t.owner_user_id = ? AND t.expires_at > ?
+		 ORDER BY t.created_at DESC`,
+		user.id,
+		Date.now(),
+	)
+}
+
+export async function createOwnedThread(
+	request: Request,
+	env: AppEnv,
+	user: UserRow,
+	input: { purpose?: unknown; name?: unknown },
+) {
+	const created = await createThread({
+		db: env.DB,
+		baseUrl: appBaseUrl(env, request),
+		ownerUserId: user.id,
+		purpose: input.purpose,
+		name: input.name || user.login,
+	})
+	if (!created.ok) return errorResponse(created)
+	return json({
+		ok: true,
+		thread: threadJson(created.thread),
+		agent: { id: created.agent.id, name: created.agent.name },
+		token: created.token,
+		join_token: created.joinToken,
+		view_url: created.viewUrl,
+		connect_prompt: created.connectPrompt,
+		join_prompt: created.joinPrompt,
+		plan: created.plan,
+	})
+}
+
+export async function handleUserApi(
+	request: Request,
+	env: AppEnv,
+	user: UserRow,
+) {
+	const url = new URL(request.url)
+	if (url.pathname === '/api/me' && request.method === 'GET') {
+		return json({
+			ok: true,
+			user: {
+				id: user.id,
+				login: user.login,
+				name: user.name,
+				plan: user.plan,
+			},
+		})
+	}
+
+	if (url.pathname === '/api/threads' && request.method === 'GET') {
+		const threads = await listOwnedThreads(env, user)
+		return json({
+			ok: true,
+			threads: threads.map((thread) => ({
+				...threadJson(thread),
+				member_count: Number(thread.member_count),
+			})),
+		})
+	}
+
+	if (url.pathname === '/api/threads' && request.method === 'POST') {
+		const body = await readJson(request)
+		if (!body)
+			return json({ ok: false, error: 'Invalid JSON.', code: 'bad_json' }, 400)
+		return createOwnedThread(request, env, user, body)
+	}
+
+	const threadPath = url.pathname.match(/^\/api\/threads\/([^/]+)$/)
+	if (threadPath?.[1] && request.method === 'GET') {
+		const owned = await requireOwnedThread(env, user, threadPath[1])
+		if (!owned.ok) return owned.response
+		return json({ ok: true, thread: threadJson(owned.thread) })
+	}
+
+	const messages = url.pathname.match(/^\/api\/threads\/([^/]+)\/messages$/)
+	if (messages?.[1] && request.method === 'GET') {
+		const owned = await requireOwnedThread(env, user, messages[1])
+		if (!owned.ok) return owned.response
+		const listed = await listMessages({
+			db: env.DB,
+			threadId: owned.thread.id,
+			agent: owned.host,
+			after: url.searchParams.get('after'),
+			limit: Number(url.searchParams.get('limit') ?? 50),
+		})
+		if (!listed.ok) return errorResponse(listed)
+		return json({
+			ok: true,
+			messages: listed.messages,
+			retry_after: listed.retryAfter,
+		})
+	}
+	if (messages?.[1] && request.method === 'POST') {
+		const owned = await requireOwnedThread(env, user, messages[1])
+		if (!owned.ok) return owned.response
+		const body = await readJson(request)
+		if (!body)
+			return json({ ok: false, error: 'Invalid JSON.', code: 'bad_json' }, 400)
+		const sent = await sendMessage({
+			db: env.DB,
+			threadId: owned.thread.id,
+			agent: owned.host,
+			body: body.body,
+			kind: body.kind,
+			refs: body.refs,
+		})
+		if (!sent.ok) return errorResponse(sent)
+		return json({ ok: true, message: sent.message })
+	}
+
+	const webhook = url.pathname.match(/^\/api\/threads\/([^/]+)\/webhook$/)
+	if (webhook?.[1] && request.method === 'PUT') {
+		const owned = await requireOwnedThread(env, user, webhook[1])
+		if (!owned.ok) return owned.response
+		const body = await readJson(request)
+		if (!body)
+			return json({ ok: false, error: 'Invalid JSON.', code: 'bad_json' }, 400)
+		const result = await setWebhook({
+			db: env.DB,
+			threadId: owned.thread.id,
+			agent: owned.host,
+			url: body.url,
+		})
+		if (!result.ok) return errorResponse(result)
+		return json({ ok: true, url: result.url })
+	}
+
+	return json({ ok: false, error: 'Not found.', code: 'not_found' }, 404)
+}
+
+export async function joinAsUser(
+	env: AppEnv,
+	input: { threadId: string; joinToken: unknown; name?: unknown },
+) {
+	if (typeof input.joinToken !== 'string') {
+		return json(
+			{ ok: false, error: 'join_token is required.', code: 'bad_join' },
+			400,
+		)
+	}
+	const joined = await joinThread({
+		db: env.DB,
+		threadId: input.threadId,
+		joinToken: input.joinToken,
+		name: input.name,
+	})
+	if (!joined.ok) return errorResponse(joined)
+	return json({
+		ok: true,
+		thread: threadJson(joined.thread),
+		agent: { id: joined.agent.id, name: joined.agent.name },
+		token: joined.token,
+		plan: joined.plan,
+	})
+}

--- a/src/user-api.ts
+++ b/src/user-api.ts
@@ -117,6 +117,7 @@ export async function handleUserApi(
 	request: Request,
 	env: AppEnv,
 	user: UserRow,
+	ctx?: ExecutionContext,
 ) {
 	const url = new URL(request.url)
 	if (url.pathname === '/api/me' && request.method === 'GET') {
@@ -189,7 +190,7 @@ export async function handleUserApi(
 			refs: body.refs,
 		})
 		if (!sent.ok) return errorResponse(sent)
-		await maybeDispatchWebhook(env.DB, owned.thread.id, sent.message)
+		await maybeDispatchWebhook(env.DB, owned.thread.id, sent.message, ctx)
 		return json({ ok: true, message: sent.message })
 	}
 

--- a/src/user-api.ts
+++ b/src/user-api.ts
@@ -6,6 +6,7 @@ import {
 	getHostAgent,
 	joinThread,
 	listMessages,
+	maybeDispatchWebhook,
 	sendMessage,
 	setWebhook,
 	type ThreadRow,
@@ -188,6 +189,7 @@ export async function handleUserApi(
 			refs: body.refs,
 		})
 		if (!sent.ok) return errorResponse(sent)
+		await maybeDispatchWebhook(env.DB, owned.thread.id, sent.message)
 		return json({ ok: true, message: sent.message })
 	}
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,48 @@
+import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
+import { handleRequest } from '#src/index.ts'
+import { type AppEnv } from '#src/env.ts'
+import { oauthPaths, oauthScopes } from '#src/oauth-paths.ts'
+import { userFromGrantProps } from '#src/oauth-user.ts'
+import { purgeExpired } from '#src/threads.ts'
+import { handleUserApi } from '#src/user-api.ts'
+
+const apiHandler = {
+	async fetch(request: Request, env: AppEnv, ctx: ExecutionContext) {
+		const props = ctx.props as { userId?: string } | undefined
+		const user = await userFromGrantProps(env, props)
+		if (!user) {
+			return Response.json(
+				{ ok: false, error: 'Unknown user.', code: 'invalid_token' },
+				{ status: 401 },
+			)
+		}
+		return handleUserApi(request, env, user)
+	},
+}
+
+const defaultHandler = {
+	async fetch(request: Request, env: AppEnv) {
+		return handleRequest(request, env)
+	},
+}
+
+const oauthProvider = new OAuthProvider({
+	apiRoute: oauthPaths.apiPrefix,
+	apiHandler,
+	defaultHandler,
+	authorizeEndpoint: oauthPaths.authorize,
+	tokenEndpoint: oauthPaths.token,
+	clientRegistrationEndpoint: oauthPaths.register,
+	scopesSupported: [...oauthScopes],
+	clientIdMetadataDocumentEnabled: true,
+	onError: () => undefined,
+})
+
+export default {
+	fetch(request: Request, env: AppEnv, ctx: ExecutionContext) {
+		return oauthProvider.fetch(request, env, ctx)
+	},
+	async scheduled(_event: ScheduledEvent, env: AppEnv) {
+		await purgeExpired(env.DB)
+	},
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -16,13 +16,13 @@ const apiHandler = {
 				{ status: 401 },
 			)
 		}
-		return handleUserApi(request, env, user)
+		return handleUserApi(request, env, user, ctx)
 	},
 }
 
 const defaultHandler = {
-	async fetch(request: Request, env: AppEnv) {
-		return handleRequest(request, env)
+	async fetch(request: Request, env: AppEnv, ctx: ExecutionContext) {
+		return handleRequest(request, env, ctx)
 	},
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,9 +1,9 @@
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "kody-exchange",
-	"main": "src/index.ts",
+	"main": "src/worker.ts",
 	"compatibility_date": "2026-04-16",
-	"compatibility_flags": ["nodejs_compat"],
+	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
 	"minify": true,
 	"workers_dev": true,
 	"preview_urls": false,
@@ -25,6 +25,10 @@
 		{
 			"binding": "RATE_LIMIT",
 			"id": "4906d4b4b37b465d9548ee845a55e64b",
+		},
+		{
+			"binding": "OAUTH_KV",
+			"id": "b7f020cdff1c4dc4b813cbffbd436fcf",
 		},
 	],
 	"r2_buckets": [


### PR DESCRIPTION
The read-only thread page always shows a **Guest** copy prompt. The **Host** prompt is only shown when the signed-in user owns the thread.

- Public / unauthenticated view: Guest only. No host live token in the HTML.
- Signed-in stranger: Guest only.
- Signed-in owner: Host + Guest.
- Guest-created threads: Guest only.

Connect/join prompts mention the existing HTTPS webhook so agents can receive messages without polling.

## OAuth + authenticated MCP

kody.exchange is now an OAuth 2.1 authorization server in the same shape as kody.codes (`@cloudflare/workers-oauth-provider`, `OAUTH_KV`, DCR, PKCE S256):

- `/.well-known/oauth-authorization-server`
- `/.well-known/oauth-protected-resource` (resource is `/mcp`)
- `POST /oauth/register`
- `GET/POST /oauth/authorize` (GitHub sign-in, then consent)
- `POST /oauth/token`
- Authenticated user API under `/api/` (`/me`, threads, messages, webhook)
- `POST /mcp` requires an OAuth bearer token

Guest create stays on unauthenticated `POST /v1/threads`. The private Kody package `@kentcdodds/exchange-threads` creates and receives threads through that OAuth connection.

Outbound webhooks stay off the send response path and are kept alive with `ctx.waitUntil` so Workers do not drop the fetch.

`npm run validate` green (32 tests).
