### PR TITLE
Sell /api and /mcp as the free-account upgrade from guest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,4 @@ This file is brief. Skills and docs:
   `GET https://kody.exchange/health` until `commit` matches the merge SHA.
 - Do not `wrangler secret put` by hand. Deploy syncs Actions secrets.
 - Guest is one live thread per IP via REST `POST /v1/threads`. `/mcp` and
-  `/api/` require an OAuth access token.
+  `/api/` require an OAuth access token from a free GitHub account.

--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -13,7 +13,7 @@ Stable nouns. Not a changelog.
 ## Invariants
 
 - Guest create works with no secrets other than rate-limit KV.
-- Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. Guest create is REST `POST /v1/threads` (no token). `/mcp` and `/api/` require an OAuth access token for the signed-in account.
+- Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. Guest create is REST `POST /v1/threads` (no token). `/mcp` and `/api/` require an OAuth access token for a signed-in account. That surface is the guest→free upsell (GitHub sign-in), not a paid gate.
 - Guest polls wait 5 seconds. Poll rate limits use Cache first and write KV at most every 30 seconds.
 - Shareable `/t/{id}/{viewToken}` cannot send from the browser. Guest copy prompt is always shown. Host copy prompt is only for the signed-in thread owner. View polls are IP-limited at 5 seconds.
 - Actions `OAUTH_GITHUB_*` map to Worker `GITHUB_*` (Actions reserves `GITHUB_*`).

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -38,6 +38,8 @@ Respect `Retry-After`. Guest threads: one live thread per IP, 5 seconds between 
 
 ## OAuth and MCP
 
+Included with a free GitHub account — not a paid upgrade. Guest create stays on `POST /v1/threads`. Sign in, then use `/api/` or `/mcp`.
+
 kody.exchange is an OAuth 2.1 authorization server (same shape as kody.codes):
 
 - Discovery: `GET /.well-known/oauth-authorization-server`
@@ -53,4 +55,4 @@ Authenticated user API (bearer access token):
 - `GET/POST /api/threads/{id}/messages`
 - `PUT /api/threads/{id}/webhook`
 
-`POST /mcp` is the same surface as JSON-RPC tools (`create_thread`, `list_threads`, `join_thread`, `send_message`, `list_messages`, `set_webhook`). Unauthenticated MCP calls return `401` with `WWW-Authenticate` so clients can start OAuth. Guest create stays on `POST /v1/threads` with no token.
+`POST /mcp` is the same surface as JSON-RPC tools (`create_thread`, `list_threads`, `join_thread`, `send_message`, `list_messages`, `set_webhook`). Unauthenticated `/api` and `/mcp` calls return `401` with `WWW-Authenticate` plus a free-account `signup_url`. Guest create stays on `POST /v1/threads` with no token.

--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -28,6 +28,9 @@ test('guest thread: create, join, send, poll, and health', async () => {
 	expect(html).toContain('Humans watch a read-only chat')
 	expect(html).not.toContain('SMTP')
 	expect(html).not.toContain('Max')
+	expect(html).toContain('unlock the OAuth API and MCP')
+	expect(html).toContain('/api and /mcp instead of guest /v1')
+	expect(html).toContain('Pro is for more threads')
 
 	const createdResponse = await handleRequest(
 		request('/v1/threads', {
@@ -136,8 +139,19 @@ test('guest thread: create, join, send, poll, and health', async () => {
 		env,
 	)
 	expect(sameIp.status).toBe(429)
-	const sameIpJson = (await sameIp.json()) as { code: string }
+	const sameIpJson = (await sameIp.json()) as {
+		code: string
+		error: string
+		signup_url: string
+		mcp_url: string
+		hint: string
+	}
 	expect(sameIpJson.code).toBe('guest_thread_limit')
+	expect(sameIpJson.error).toContain('free account')
+	expect(sameIpJson.error).toContain('/api and /mcp')
+	expect(sameIpJson.signup_url).toBe('https://kody.exchange/auth/github')
+	expect(sameIpJson.mcp_url).toBe('https://kody.exchange/mcp')
+	expect(sameIpJson.hint).toContain('not a paid upgrade')
 
 	const viewPath = new URL(created.view_url).pathname
 	const viewPage = await handleRequest(request(viewPath), env)
@@ -250,6 +264,27 @@ test('view host prompt token can send on that thread but cannot open another', a
 		env,
 	)
 	expect(createWithViewHost.status).toBe(401)
+
+	const createWithGuestLive = await handleRequest(
+		request('/v1/threads', {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${created.token}`,
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({ purpose: 'should fail', name: 'nope' }),
+		}),
+		env,
+	)
+	expect(createWithGuestLive.status).toBe(403)
+	const guestReadonly = (await createWithGuestLive.json()) as {
+		code: string
+		signup_url: string
+		hint: string
+	}
+	expect(guestReadonly.code).toBe('guest_readonly')
+	expect(guestReadonly.signup_url).toBe('https://kody.exchange/auth/github')
+	expect(guestReadonly.hint).toContain('free account')
 })
 
 test('pricing page explains live threads and participants', async () => {
@@ -260,4 +295,13 @@ test('pricing page explains live threads and participants', async () => {
 	expect(html).toContain('participants per thread')
 	expect(html).toContain('$5')
 	expect(html).not.toContain('Max')
+	expect(html).toContain('unlocks the OAuth API and MCP')
+	expect(html).toContain('HTTP /v1 only')
+	expect(html).toContain('OAuth API + MCP')
+
+	const docs = await handleRequest(request('/docs'), env)
+	const docsHtml = await docs.text()
+	expect(docsHtml).toContain('Included with a free GitHub account')
+	expect(docsHtml).toContain('not a paid upgrade')
+	expect(docsHtml).not.toContain('Max')
 })

--- a/src/api.ts
+++ b/src/api.ts
@@ -22,6 +22,7 @@ import {
 } from '#src/threads.ts'
 import { createId } from '#src/ids.ts'
 import { first, run } from '#src/db.ts'
+import { freeAccountUpsell, isGuestUpsellCode } from '#src/free-account.ts'
 
 export function json(data: unknown, status = 200, extra: HeadersInit = {}) {
 	const headers = new Headers(extra)
@@ -44,11 +45,22 @@ function bearer(request: Request) {
 	return token.length > 0 ? token : null
 }
 
-export function errorResponse(error: DomainError, retryAfter?: number) {
+export function errorResponse(
+	error: DomainError,
+	retryAfter?: number,
+	origin?: string,
+) {
 	const headers: Record<string, string> = {}
 	if (retryAfter !== undefined) headers['retry-after'] = String(retryAfter)
 	return json(
-		{ ok: false, error: error.error, code: error.code },
+		{
+			ok: false,
+			error: error.error,
+			code: error.code,
+			...(origin && isGuestUpsellCode(error.code)
+				? freeAccountUpsell(origin)
+				: {}),
+		},
 		error.status,
 		headers,
 	)
@@ -157,6 +169,7 @@ async function createThreadRoute(request: Request, env: AppEnv) {
 	if (!body)
 		return json({ ok: false, error: 'Invalid JSON.', code: 'bad_json' }, 400)
 
+	const origin = appBaseUrl(env, request)
 	const token = bearer(request)
 	let ownerUserId: string | null = null
 	if (token) {
@@ -171,8 +184,10 @@ async function createThreadRoute(request: Request, env: AppEnv) {
 			return json(
 				{
 					ok: false,
-					error: 'Guest tokens cannot open another thread.',
+					error:
+						'Guest tokens cannot open another thread. Sign in with GitHub for a free account to use /api and /mcp.',
 					code: 'guest_readonly',
+					...freeAccountUpsell(origin),
 				},
 				403,
 			)
@@ -187,8 +202,10 @@ async function createThreadRoute(request: Request, env: AppEnv) {
 			return json(
 				{
 					ok: false,
-					error: 'Too many guest threads from this IP.',
+					error:
+						'Too many guest threads from this IP. Sign in with GitHub for a free account to use /api and /mcp.',
 					code: 'rate_limited',
+					...freeAccountUpsell(origin),
 				},
 				429,
 				{ 'retry-after': String(limited.retryAfterSeconds) },
@@ -204,7 +221,7 @@ async function createThreadRoute(request: Request, env: AppEnv) {
 		purpose: body.purpose,
 		name: body.name,
 	})
-	if (!created.ok) return errorResponse(created)
+	if (!created.ok) return errorResponse(created, undefined, origin)
 	return json({
 		ok: true,
 		thread: threadJson(created.thread),

--- a/src/free-account.ts
+++ b/src/free-account.ts
@@ -1,0 +1,22 @@
+export const freeAccountHint =
+	'Sign in with GitHub for a free account. That unlocks /api and /mcp so your agent can create owned threads without guest IP limits. This is not a paid upgrade.'
+
+export function isGuestUpsellCode(code: string) {
+	switch (code) {
+		case 'guest_capacity':
+		case 'guest_readonly':
+		case 'guest_thread_limit':
+			return true
+		default:
+			return false
+	}
+}
+
+export function freeAccountUpsell(origin: string) {
+	return {
+		signup_url: `${origin}/auth/github`,
+		mcp_url: `${origin}/mcp`,
+		api_prefix: `${origin}/api/`,
+		hint: freeAccountHint,
+	}
+}

--- a/src/html.ts
+++ b/src/html.ts
@@ -357,10 +357,10 @@ export function homePage(baseUrl: string) {
 	${promptCard({
 		id: 'prompt',
 		title: 'Copy this into the agent you already use',
-		hint: 'Or sign in and create the thread yourself — then you will get both prompts.',
+		hint: 'Or sign in (free) so your agent can use /api and /mcp instead of guest /v1.',
 		prompt: homepagePrompt(baseUrl),
 	})}
-	<p class="tiny">Guest threads last ${plans.guest.retentionLabel}, hold ${plans.guest.liveAgents} participants, and ${plans.guest.messagesPerMonth} messages — one live thread per IP. Sign in with GitHub for a Free account — or Pro when you need more threads, more participants, and blobs.</p>
+	<p class="tiny">Guest threads last ${plans.guest.retentionLabel}, hold ${plans.guest.liveAgents} participants, and ${plans.guest.messagesPerMonth} messages — one live thread per IP. Sign in with GitHub for a Free account to unlock the OAuth API and MCP. Pro is for more threads, more participants, and blobs.</p>
 	${copyPromptScript()}
 	`
 }
@@ -368,7 +368,7 @@ export function homePage(baseUrl: string) {
 export function pricingPage() {
 	return `
 	<h1>Pricing</h1>
-	<p class="lede">You pay for live threads and how many agents can sit in one — not a daily allowance. A Free account can keep 3 threads with 3 participants each.</p>
+	<p class="lede">You pay for live threads and how many agents can sit in one — not a daily allowance. A Free account unlocks the OAuth API and MCP, and can keep 3 threads with 3 participants each.</p>
 	<div class="plans">
 		${planCard('guest')}
 		${planCard('free')}
@@ -390,6 +390,7 @@ function planCard(name: 'guest' | 'free' | 'pro') {
 		<h2>${plan.label}</h2>
 		<p class="price">${price}${plan.priceMonthlyUsd ? '<span class="tiny">/mo</span>' : ''}</p>
 		<ul>
+			<li>${name === 'guest' ? 'HTTP /v1 only' : 'OAuth API + MCP'}</li>
 			<li>${plan.threads} live threads</li>
 			<li>${plan.liveAgents} participants per thread</li>
 			<li>${plan.messagesPerMonth.toLocaleString()} messages / calendar month</li>
@@ -426,7 +427,7 @@ Content-Type: application/json
 Authorization: Bearer kx_live_…</pre>
 	<p>Optional webhook: <code>PUT /v1/threads/{id}/webhook</code> with <code>{"url":"https://…"}</code>.</p>
 	<h2>OAuth / MCP</h2>
-	<p>Integrations (including kody.codes) authenticate with OAuth. Discovery is at <code>/.well-known/oauth-authorization-server</code>. MCP at <code>/mcp</code> requires a bearer access token. The signed-in user API is under <code>/api/</code> (<code>/api/me</code>, <code>/api/threads</code>).</p>
+	<p>Included with a free GitHub account — not a paid upgrade. Guest create stays on <code>POST /v1/threads</code>. Sign in, then use <code>/api/</code> or point an MCP client at <code>/mcp</code>. Discovery is at <code>/.well-known/oauth-authorization-server</code>.</p>
 	<p class="tiny">Envelope: <code>id</code>, <code>at</code>, <code>from</code>, <code>thread</code>, <code>kind</code>, <code>body</code>, <code>refs[]</code>.</p>
 	`
 }

--- a/src/mcp.node.test.ts
+++ b/src/mcp.node.test.ts
@@ -31,6 +31,28 @@ test('MCP guest creates are no longer allowed without OAuth', async () => {
 	expect(response.headers.get('www-authenticate')).toContain(
 		'resource_metadata=',
 	)
+	const body = (await response.json()) as {
+		error: string
+		signup_url: string
+		hint: string
+	}
+	expect(body.error).toContain('free account')
+	expect(body.signup_url).toBe('https://kody.exchange/auth/github')
+	expect(body.hint).toContain('not a paid upgrade')
+	expect(body.hint).not.toContain('Pro')
+})
+
+test('MCP browser landing sells a free GitHub account', async () => {
+	const env = createTestEnv()
+	const response = await handleRequest(
+		request('/mcp', { headers: { accept: 'text/html' } }),
+		env,
+	)
+	expect(response.status).toBe(200)
+	const html = await response.text()
+	expect(html).toContain('included with a free GitHub account')
+	expect(html).toContain('/auth/github')
+	expect(html).not.toContain('Pro')
 })
 
 test('OAuth MCP create_thread opens an account-owned thread', async () => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,6 +1,6 @@
 import { json } from '#src/api.ts'
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
-import { layout } from '#src/html.ts'
+import { escapeHtml, layout } from '#src/html.ts'
 import { createOwnedThread, handleUserApi, joinAsUser } from '#src/user-api.ts'
 import { type UserRow } from '#src/threads.ts'
 
@@ -107,7 +107,9 @@ export function mcpBrowserLanding(
 			env,
 			path: '/mcp',
 			title: 'MCP',
-			body: `<h1>kody.exchange MCP</h1><p>This endpoint is OAuth-protected. Point an MCP client at <code>${appBaseUrl(env, request)}/mcp</code> and complete the authorization prompt.</p>`,
+			body: user
+				? `<h1>kody.exchange MCP</h1><p>Point an MCP client at <code>${appBaseUrl(env, request)}/mcp</code> and approve the prompt as @${escapeHtml(user.login)}. This is included with your free account.</p>`
+				: `<h1>kody.exchange MCP</h1><p>MCP is included with a free GitHub account. <a href="/auth/github">Sign in</a>, then point an MCP client at <code>${appBaseUrl(env, request)}/mcp</code> and complete the authorization prompt.</p>`,
 		}),
 		{ headers: { 'content-type': 'text/html; charset=utf-8' } },
 	)

--- a/src/oauth-user.ts
+++ b/src/oauth-user.ts
@@ -1,6 +1,7 @@
 import { json } from '#src/api.ts'
 import { first } from '#src/db.ts'
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
+import { freeAccountUpsell } from '#src/free-account.ts'
 import {
 	mcpResourcePath,
 	oauthScopes,
@@ -73,8 +74,10 @@ export function unauthorizedOAuthResponse(origin: string) {
 	return json(
 		{
 			ok: false,
-			error: 'Authentication required. Obtain an access token via OAuth.',
+			error:
+				'Sign in with GitHub for a free account, then connect OAuth to use /api and /mcp.',
 			code: 'invalid_token',
+			...freeAccountUpsell(origin),
 		},
 		401,
 		{

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -75,6 +75,17 @@ test('unauthenticated MCP and /api return 401 with WWW-Authenticate', async () =
 
 	const api = await handleRequest(request('/api/me'), env)
 	expect(api.status).toBe(401)
+	const apiBody = (await api.json()) as {
+		error: string
+		signup_url: string
+		mcp_url: string
+		hint: string
+	}
+	expect(apiBody.error).toContain('free account')
+	expect(apiBody.error).not.toContain('Pro')
+	expect(apiBody.signup_url).toBe('https://kody.exchange/auth/github')
+	expect(apiBody.mcp_url).toBe('https://kody.exchange/mcp')
+	expect(apiBody.hint).toContain('not a paid upgrade')
 })
 
 test('authorize redirects signed-out users to GitHub with next', async () => {

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -29,6 +29,7 @@ test('signed-in account is threads, not agent tokens', async () => {
 	expect(html).not.toContain('Create agent token')
 	expect(html).not.toContain('live agent tokens')
 	expect(html).not.toContain('New agent token')
+	expect(html).toContain('included with a signed-in account')
 })
 
 test('creating a thread shows a connect prompt and a join prompt once', async () => {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -272,7 +272,7 @@ async function accountPage(
 	<h1>Threads</h1>
 	<p class="lede">@${escapeHtml(user.login)} · ${escapeHtml(plan.label)} · ${liveThreads}/${plan.threads} live</p>
 	<p>A thread is a room. You create it here, then we give you two prompts to copy. You do not invent tokens.</p>
-	<p class="tiny">Integrations (Claude, Cursor, kody.codes) connect with OAuth. Point them at <code>${escapeHtml(appBaseUrl(env, request))}/mcp</code> and approve the prompt. Guest threads still work over plain <code>/v1</code> with no account.</p>
+	<p class="tiny">OAuth API and MCP are included with a signed-in account. Point integrations at <code>${escapeHtml(appBaseUrl(env, request))}/mcp</code> and approve the prompt. Guest threads still work over plain <code>/v1</code> with no account.</p>
 	${upgraded ? `<p class="card">Pro is active. Thank you.</p>` : ''}
 	${error ? `<p class="card">${escapeHtml(error)}</p>` : ''}
 	${flash ? threadFlashHtml(flash) : ''}

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -379,7 +379,7 @@ export async function createThread(input: {
 			return fail(
 				503,
 				'guest_capacity',
-				'Guest threads are at capacity. Try again later or sign in.',
+				'Guest threads are at capacity. Sign in with GitHub for a free account to use /api and /mcp.',
 			)
 		}
 		const ipLive = await countGuestThreadsForIp(input.db, ip, now)
@@ -387,7 +387,7 @@ export async function createThread(input: {
 			return fail(
 				429,
 				'guest_thread_limit',
-				'This IP already has a live guest thread. Wait for it to expire, or sign in.',
+				'This IP already has a live guest thread. Sign in with GitHub for a free account to use /api and /mcp.',
 			)
 		}
 	}


### PR DESCRIPTION
Guest `/v1` stays free and anonymous. The authenticated **API** and **MCP** are the reason to sign in with GitHub — a Free account, not Pro.

- Unauthenticated `/api` and `/mcp` 401s keep OAuth `WWW-Authenticate` and now include `signup_url`, `mcp_url`, and a hint that this is not a paid upgrade.
- Guest walls (IP thread limit, capacity, guest-token create, guest create rate limit) point at the same free-account path.
- Homepage, docs, pricing, and the MCP landing page say Free unlocks OAuth API + MCP. Pro stays more rooms, more participants, and blobs.

`npm run validate` green (33 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSON error enrichment only; no changes to OAuth validation or guest thread rules beyond message text.
> 
> **Overview**
> Reframes **OAuth `/api` and `/mcp`** as the reason to sign in with GitHub (free account), not Pro. Guest anonymous **`POST /v1/threads`** is unchanged.
> 
> Adds **`src/free-account.ts`** with shared **`signup_url`**, **`mcp_url`**, **`api_prefix`**, and a **`hint`** that this is not a paid upgrade. **`errorResponse`** and guest create paths attach these fields for codes like **`guest_thread_limit`**, **`guest_capacity`**, and **`guest_readonly`**. Unauthenticated **`/api`** and **`/mcp`** 401s keep **`WWW-Authenticate`** and now include the same upsell payload.
> 
> Copy updates on the homepage, pricing (guest = HTTP `/v1` only; free+ = OAuth API + MCP), docs, MCP HTML landing, and account threads page. **`threads.ts`** guest limit messages point at sign-in for `/api` and `/mcp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95028ac7d3848b74722c05832b3a82193bafaa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->