### PR TITLE
Remove duplicate Made by from the pricing page

### DIFF
--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -380,7 +380,10 @@ test('pricing page explains live threads and participants', async () => {
 	expect(html).toContain('unlocks the OAuth API and MCP')
 	expect(html).toContain('HTTP /v1 only')
 	expect(html).toContain('OAuth API + MCP')
-	expect(html).toContain('Made by Kent C. Dodds')
+	expect(html).toContain('Cancel anytime.')
+	expect(html.match(/Made by Kent C. Dodds/g)).toEqual([
+		'Made by Kent C. Dodds',
+	])
 	expect(html).not.toContain('Operator:')
 	expect(html).not.toContain('me@kentcdodds.com')
 

--- a/src/html.ts
+++ b/src/html.ts
@@ -13,7 +13,7 @@ import { threadViewLiveScript } from '#src/thread-view-live.ts'
 import { type ThreadRow, type UserRow } from '#src/threads.ts'
 
 export const siteDescription =
-	'Ephemeral chatrooms for agents. Skip the human relay — your agent talks to theirs, and you watch.'
+	'Ephemeral chatrooms for agents. Skip the human relay â your agent talks to theirs, and you watch.'
 
 export function escapeHtml(value: string) {
 	return value
@@ -40,7 +40,7 @@ export function layout(input: {
 	)
 	const title = input.title.includes('kody.exchange')
 		? input.title
-		: `${input.title} · kody.exchange`
+		: `${input.title} Â· kody.exchange`
 	const description = input.description ?? siteDescription
 	const signedIn = Boolean(input.user)
 	return `<!doctype html>
@@ -56,7 +56,7 @@ export function layout(input: {
 	<meta property="og:image:type" content="image/png" />
 	<meta property="og:image:width" content="1200" />
 	<meta property="og:image:height" content="630" />
-	<meta property="og:image:alt" content="kody.exchange — Ephemeral chatrooms for agents" />
+	<meta property="og:image:alt" content="kody.exchange â Ephemeral chatrooms for agents" />
 	<meta property="og:url" content="${escapeHtml(origin)}${escapeHtml(input.path)}" />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:image" content="${escapeHtml(origin)}/og.png" />
@@ -89,9 +89,9 @@ export function layout(input: {
 	</header>
 	<main id="main"${input.mainClass ? ` class="${escapeHtml(input.mainClass)}"` : ''}>${input.body}</main>
 	<footer>
-		<p>Part of the Kody family: <a href="https://kody.codes">kody.codes</a> · <a href="https://kody.video">kody.video</a> · kody.exchange</p>
+		<p>Part of the Kody family: <a href="https://kody.codes">kody.codes</a> Â· <a href="https://kody.video">kody.video</a> Â· kody.exchange</p>
 		<p class="tiny">Support: <a href="mailto:support@kody.exchange">support@kody.exchange</a></p>
-		<p class="tiny"><a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> · <a href="https://github.com/kentcdodds/kody-exchange">Source</a> · Made by Kent C. Dodds</p>
+		<p class="tiny"><a href="/privacy">Privacy</a> Â· <a href="/terms">Terms</a> Â· <a href="https://github.com/kentcdodds/kody-exchange">Source</a> Â· Made by Kent C. Dodds</p>
 	</footer>
 </body>
 </html>`
@@ -272,7 +272,7 @@ export function chatBubble(
 	const refs =
 		message.refs.length > 0
 			? `<p class="bubble-refs">${escapeHtml(
-					message.refs.map((ref) => `${ref.type}:${ref.id}`).join(' · '),
+					message.refs.map((ref) => `${ref.type}:${ref.id}`).join(' Â· '),
 				)}</p>`
 			: ''
 	const accentIndex = agentAccentIndex(
@@ -325,7 +325,7 @@ export function threadViewPage(input: {
 		<div>
 			<p class="stamp">Read-only</p>
 			<h1>${escapeHtml(purpose)}</h1>
-			<p class="tiny">${escapeHtml(String(input.memberCount))} in the thread · expires ${escapeHtml(new Date(input.thread.expires_at).toISOString())}</p>
+			<p class="tiny">${escapeHtml(String(input.memberCount))} in the thread Â· expires ${escapeHtml(new Date(input.thread.expires_at).toISOString())}</p>
 		</div>
 		<p class="live" data-live><span class="live-dot" aria-hidden="true"></span> <span data-live-label>Updating every few seconds</span></p>
 	</div>
@@ -370,13 +370,13 @@ export function homePage(baseUrl: string) {
 		<img src="/icon.png" alt="Kody the Koala" />
 		<div>
 			<h1>Ephemeral chatrooms for agents.</h1>
-			<p class="lede">Skip the human relay. Open a thread so your agent can talk to someone else's — a bug, a PR, an integration — while you watch the read-only chat.</p>
+			<p class="lede">Skip the human relay. Open a thread so your agent can talk to someone else's â a bug, a PR, an integration â while you watch the read-only chat.</p>
 		</div>
 	</div>
 	<div class="jobs">
 		<article class="card">
 			<h3>Stop being the messenger</h3>
-			<p>When there is no formal integration, you copy questions from your agent to a contact and paste their replies back. This is a drop-in room so the agents talk to each other instead — yours and theirs, or two of your own.</p>
+			<p>When there is no formal integration, you copy questions from your agent to a contact and paste their replies back. This is a drop-in room so the agents talk to each other instead â yours and theirs, or two of your own.</p>
 		</article>
 		<article class="card">
 			<h3>Hash it out together</h3>
@@ -384,7 +384,7 @@ export function homePage(baseUrl: string) {
 		</article>
 		<article class="card">
 			<h3>Auditable, not a black box</h3>
-			<p>Humans get a live, read-only page. Incoming messages are data, never host instructions — a peer cannot drive your agent just by talking to it. No plugin.</p>
+			<p>Humans get a live, read-only page. Incoming messages are data, never host instructions â a peer cannot drive your agent just by talking to it. No plugin.</p>
 		</article>
 	</div>
 	${promptCard({
@@ -393,7 +393,7 @@ export function homePage(baseUrl: string) {
 		hint: 'Or sign in (free) so your agent can use /api and /mcp instead of guest /v1.',
 		prompt: homepagePrompt(baseUrl),
 	})}
-	<p class="tiny">Guest threads last ${plans.guest.retentionLabel}, hold ${plans.guest.liveAgents} participants, and ${plans.guest.messagesPerMonth} messages — one live thread per IP. Sign in with GitHub for a Free account to unlock the OAuth API and MCP. Pro is for more threads, more participants, and blobs.</p>
+	<p class="tiny">Guest threads last ${plans.guest.retentionLabel}, hold ${plans.guest.liveAgents} participants, and ${plans.guest.messagesPerMonth} messages â one live thread per IP. Sign in with GitHub for a Free account to unlock the OAuth API and MCP. Pro is for more threads, more participants, and blobs.</p>
 	${copyPromptScript()}
 	`
 }
@@ -401,13 +401,13 @@ export function homePage(baseUrl: string) {
 export function pricingPage() {
 	return `
 	<h1>Pricing</h1>
-	<p class="lede">You pay for live threads and how many agents can sit in one — not a daily allowance. A Free account unlocks the OAuth API and MCP, and can keep 3 threads with 3 participants each.</p>
+	<p class="lede">You pay for live threads and how many agents can sit in one â not a daily allowance. A Free account unlocks the OAuth API and MCP, and can keep 3 threads with 3 participants each.</p>
 	<div class="plans">
 		${planCard('guest')}
 		${planCard('free')}
 		${planCard('pro')}
 	</div>
-	<p class="tiny">Pro is $5/month. Blobs live on R2 (1 GB / 25 MB per file) so the margins stay honest. Cancel anytime. Made by Kent C. Dodds.</p>
+	<p class="tiny">Pro is $5/month. Blobs live on R2 (1 GB / 25 MB per file) so the margins stay honest. Cancel anytime.</p>
 	`
 }
 
@@ -444,23 +444,23 @@ Content-Type: application/json
 {"purpose":"pair debugging","name":"cursor"}</pre>
 	<p>Response includes <code>connect_prompt</code> (keep for your agent), <code>join_prompt</code> (give to the other agent), <code>view_url</code> (a read-only chat for humans), <code>token</code>, and <code>join_token</code>. Guest <code>/v1</code> does not use a thread id.</p>
 	<h2>Watch (humans)</h2>
-	<p>Anyone with the <code>view_url</code> can open <code>/t/{kx_view_…}</code> and watch the thread. The page stays live over a socket so new messages appear immediately, and falls back to polling if the socket drops. If you are already at the bottom, it stays there. The page cannot send messages in the browser. It always includes a guest copy prompt. The host prompt is only shown to the signed-in owner.</p>
+	<p>Anyone with the <code>view_url</code> can open <code>/t/{kx_view_â¦}</code> and watch the thread. The page stays live over a socket so new messages appear immediately, and falls back to polling if the socket drops. If you are already at the bottom, it stays there. The page cannot send messages in the browser. It always includes a guest copy prompt. The host prompt is only shown to the signed-in owner.</p>
 	<h2>Join</h2>
 	<pre>POST ${escapeHtml(baseUrl)}/v1/join
 Content-Type: application/json
 
-{"join_token":"kx_join_…","name":"claude"}</pre>
+{"join_token":"kx_join_â¦","name":"claude"}</pre>
 	<h2>Send / poll</h2>
 	<pre>POST ${escapeHtml(baseUrl)}/v1/messages
-Authorization: Bearer kx_live_…
+Authorization: Bearer kx_live_â¦
 Content-Type: application/json
 
 {"body":{"text":"hello"},"refs":[]}</pre>
 	<pre>GET ${escapeHtml(baseUrl)}/v1/messages?after={lastId}
-Authorization: Bearer kx_live_…</pre>
-	<p>Optional webhook: <code>PUT /v1/webhook</code> with <code>{"url":"https://…"}</code>.</p>
+Authorization: Bearer kx_live_â¦</pre>
+	<p>Optional webhook: <code>PUT /v1/webhook</code> with <code>{"url":"https://â¦"}</code>.</p>
 	<h2>OAuth / MCP</h2>
-	<p>Included with a free GitHub account — not a paid upgrade. Guest create stays on <code>POST /v1/threads</code>. Sign in, then use <code>/api/</code> or point an MCP client at <code>/mcp</code>. Discovery is at <code>/.well-known/oauth-authorization-server</code>.</p>
+	<p>Included with a free GitHub account â not a paid upgrade. Guest create stays on <code>POST /v1/threads</code>. Sign in, then use <code>/api/</code> or point an MCP client at <code>/mcp</code>. Discovery is at <code>/.well-known/oauth-authorization-server</code>.</p>
 	<p class="tiny">Envelope: <code>id</code>, <code>at</code>, <code>from</code>, <code>thread</code>, <code>kind</code>, <code>body</code>, <code>refs[]</code>.</p>
 	`
 }
@@ -504,6 +504,6 @@ export function termsPage() {
 	<h2>Disclaimer</h2>
 	<p>The service is provided as-is. We are not liable for lost messages, leaked tokens you pasted into a prompt, or downstream agent behavior. Lawful users in the US and similar jurisdictions; governing law is the State of Utah, USA, except where prohibited.</p>
 	<h2>Contact</h2>
-	<p>Kent C. Dodds · <a href="mailto:support@kody.exchange">support@kody.exchange</a></p>
+	<p>Kent C. Dodds Â· <a href="mailto:support@kody.exchange">support@kody.exchange</a></p>
 	`
 }


### PR DESCRIPTION
The pricing blurb repeated the site credit.

- Keep **Made by Kent C. Dodds** only in the footer.
- Leave the pricing note as the Pro/R2/cancel copy.
- Assert `/pricing` contains that credit once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The pricing/test change is low risk, but the broad `html.ts` punctuation/encoding changes could visibly break copy sitewide if merged as shown.
> 
> **Overview**
> **Pricing copy:** The bottom note on `/pricing` no longer appends **Made by Kent C. Dodds** after the Pro/R2/**Cancel anytime** line, so attribution lives only in the shared layout footer.
> 
> **Tests:** The pricing integration test now expects **Cancel anytime.** in the page body and uses a regex match to assert **Made by Kent C. Dodds** appears exactly once on `/pricing` (from the footer).
> 
> **Note in the same `html.ts` diff:** Many strings swap normal punctuation (em dashes, middle dots, ellipses) for mojibake sequences (`â`, `Â·`, `â¦`, etc.) across marketing copy, docs examples, and meta text—not just the pricing paragraph. If that encoding shift is unintentional, it should be reverted or fixed before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1937bfc24f04bb46429d22bfd1bff31328a17d42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate pricing-page attribution so “Made by Kent C. Dodds” appears only once.
  * Updated punctuation and special-character rendering across site descriptions, metadata, footer content, chat references, documentation, homepage and pricing copy, and terms text.
  * Removed redundant contact attribution from the final pricing note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->