### PR TITLE
Keep Made by only in the site footer

### DIFF
--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -381,6 +381,8 @@ test('pricing page explains live threads and participants', async () => {
 	expect(html).toContain('HTTP /v1 only')
 	expect(html).toContain('OAuth API + MCP')
 	expect(html).toContain('Made by Kent C. Dodds')
+	expect(html.match(/Made by Kent C\. Dodds/g)).toHaveLength(1)
+	expect(html).not.toContain('Cancel anytime. Made by')
 	expect(html).not.toContain('Operator:')
 	expect(html).not.toContain('me@kentcdodds.com')
 

--- a/src/html.ts
+++ b/src/html.ts
@@ -407,7 +407,7 @@ export function pricingPage() {
 		${planCard('free')}
 		${planCard('pro')}
 	</div>
-	<p class="tiny">Pro is $5/month. Blobs live on R2 (1 GB / 25 MB per file) so the margins stay honest. Cancel anytime. Made by Kent C. Dodds.</p>
+	<p class="tiny">Pro is $5/month. Blobs live on R2 (1 GB / 25 MB per file) so the margins stay honest. Cancel anytime.</p>
 	`
 }
 

--- a/src/threads.node.test.ts
+++ b/src/threads.node.test.ts
@@ -19,13 +19,14 @@ import { run } from '#src/db.ts'
 
 test('guest thread create, join, send, and poll is a closed loop', async () => {
 	const env = createTestEnv()
+	const now = Date.parse('2026-08-14T00:00:00Z')
 	const created = await createThread({
 		db: env.DB,
 		baseUrl: 'https://kody.exchange',
 		ownerUserId: null,
 		purpose: 'pair on a bug',
 		name: 'cursor',
-		now: Date.parse('2026-08-14T00:00:00Z'),
+		now,
 	})
 	if (!created.ok) throw new Error(created.error)
 	expect(created.plan).toBe('guest')
@@ -56,7 +57,7 @@ test('guest thread create, join, send, and poll is a closed loop', async () => {
 		db: env.DB,
 		joinToken: created.joinToken,
 		name: 'claude',
-		now: Date.parse('2026-08-14T00:00:01Z'),
+		now: now + 1000,
 	})
 	if (!joined.ok) throw new Error(joined.error)
 	expect(joined.agent.name).toBe('claude')
@@ -65,6 +66,7 @@ test('guest thread create, join, send, and poll is a closed loop', async () => {
 		db: env.DB,
 		joinToken: created.joinToken,
 		name: 'extra',
+		now: now + 2000,
 	})
 	expect(third).toMatchObject({ ok: false, code: 'participant_limit' })
 
@@ -73,7 +75,7 @@ test('guest thread create, join, send, and poll is a closed loop', async () => {
 		threadId: created.thread.id,
 		agent: created.agent,
 		body: { text: 'hello from cursor' },
-		now: Date.parse('2026-08-14T00:00:02Z'),
+		now: now + 2000,
 	})
 	if (!sent.ok) throw new Error(sent.error)
 	expect(sent.message.body).toEqual({ text: 'hello from cursor' })
@@ -84,6 +86,7 @@ test('guest thread create, join, send, and poll is a closed loop', async () => {
 		threadId: created.thread.id,
 		agent: joined.agent,
 		after: '0',
+		now: now + 2000,
 	})
 	if (!listed.ok) throw new Error(listed.error)
 	expect(listed.messages).toHaveLength(1)
@@ -95,6 +98,7 @@ test('guest thread create, join, send, and poll is a closed loop', async () => {
 	const viewed = await listMessagesForView({
 		db: env.DB,
 		viewToken,
+		now: now + 2000,
 	})
 	if (!viewed.ok) throw new Error(viewed.error)
 	expect(viewed.messages).toHaveLength(1)
@@ -115,6 +119,7 @@ test('guest thread create, join, send, and poll is a closed loop', async () => {
 		db: env.DB,
 		joinToken: await joinTokenFor(created.thread),
 		name: 'from-view',
+		now: now + 2000,
 	})
 	expect(viewJoin).toMatchObject({ ok: false, code: 'participant_limit' })
 })


### PR DESCRIPTION
## Why

Pricing repeated **Made by Kent C. Dodds** in the Pro blurb and again in the shared footer.

## What changed

- Pricing copy keeps the $5 / blobs / cancel line and drops the extra credit.
- The footer credit is unchanged.
- Guest closed-loop test now passes its fixture `now` into every expiry check. Guest threads last 24 hours; the Aug 14 fixture started failing once wall-clock time passed that window.

## Risk

Low. Copy plus a test clock pin.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/pricing-made-by-once-8f73`

**Classification:** composes — pricing HTML and a unit-test clock only.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| Plan | limits | composes — pricing page copy only |
| Thread | rooms | composes — guest expiry test uses the existing 24h window |

### System map

Public pricing HTML drops a duplicate byline. The guest-thread test keeps using the same expiry rule.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  pages["pages<br/>Public HTML"]:::touched
  plan["plan<br/>guest / free / pro"]:::untouched
  pages -->|"pricing blurb no longer repeats Made by"| plan
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public copy tweak and test-only clock wiring; no auth, billing, or API behavior changes.
> 
> **Overview**
> Removes the duplicate **Made by Kent C. Dodds** line from the pricing page Pro footnote so the credit appears only in the shared site footer.
> 
> Pricing API tests now assert a single byline on `/pricing` and that the Pro blurb no longer reads `Cancel anytime. Made by`.
> 
> The guest closed-loop unit test pins a fixture `now` and passes it through create/join/send/list/view calls so expiry checks stay inside the 24-hour guest window instead of failing as real time advances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11b8d551ff7d9bb232cdeebd773b66ade1bf3db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->