### PR TITLE
Serve MCP protected-resource metadata before OAuthProvider

### DIFF
--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -15,6 +15,7 @@ Stable nouns. Not a changelog.
 
 - Guest create works with no secrets other than rate-limit KV.
 - Guest is one live thread per IP, 3 creates/hour/IP, and 1000 live guest threads globally. Guest create is REST `POST /v1/threads` (no token). `/mcp` and `/api/` require an OAuth access token for a signed-in account. That surface is the guest→free upsell (GitHub sign-in), not a paid gate.
+- Root `/.well-known/oauth-protected-resource` is served before OAuthProvider and advertises `https://kody.exchange/mcp`. The provider defaults that path to the origin only.
 - Guest polls wait 5 seconds. Poll rate limits use Cache first and write KV at most every 30 seconds.
 - Shareable `/t/{kx_view_…}` cannot send from the browser. Guest copy prompt is always shown. Host copy prompt is only for the signed-in thread owner. View polls are IP-limited at 5 seconds. The watch page prefers a read-only WebSocket on `/live`; polling is the fallback. Guest `/v1` join/send/poll/webhook/blobs infer the thread from the token — no public thread id.
 - Actions `OAUTH_GITHUB_*` map to Worker `GITHUB_*` (Actions reserves `GITHUB_*`).

--- a/src/cloudflare-workers-node.ts
+++ b/src/cloudflare-workers-node.ts
@@ -1,0 +1,6 @@
+/** Node-test stub for `cloudflare:workers`. Production uses the Workers runtime. */
+export class WorkerEntrypoint {
+	fetch() {
+		return new Response('not implemented')
+	}
+}

--- a/src/oauth-paths.ts
+++ b/src/oauth-paths.ts
@@ -16,8 +16,11 @@ export const protectedResourceMetadataPath =
 	'/.well-known/oauth-protected-resource'
 
 export function isProtectedResourceMetadataPath(pathname: string) {
+	// Root + /mcp only. Leave /api to OAuthProvider so that document still
+	// advertises https://kody.exchange/api; an /mcp audience does not cover
+	// /api/* on the provider's apiRoute check.
 	return (
 		pathname === protectedResourceMetadataPath ||
-		pathname.startsWith(`${protectedResourceMetadataPath}/`)
+		pathname === `${protectedResourceMetadataPath}${mcpResourcePath}`
 	)
 }

--- a/src/oauth-paths.ts
+++ b/src/oauth-paths.ts
@@ -11,5 +11,13 @@ export const oauthPaths = {
 export const oauthScopes = ['profile', 'threads'] as const
 
 export const mcpResourcePath = '/mcp'
+export const apiResourcePath = '/api'
 export const protectedResourceMetadataPath =
 	'/.well-known/oauth-protected-resource'
+
+export function isProtectedResourceMetadataPath(pathname: string) {
+	return (
+		pathname === protectedResourceMetadataPath ||
+		pathname.startsWith(`${protectedResourceMetadataPath}/`)
+	)
+}

--- a/src/oauth-user.ts
+++ b/src/oauth-user.ts
@@ -3,6 +3,7 @@ import { first } from '#src/db.ts'
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
 import { freeAccountUpsell } from '#src/free-account.ts'
 import {
+	apiResourcePath,
 	mcpResourcePath,
 	oauthScopes,
 	protectedResourceMetadataPath,
@@ -90,16 +91,23 @@ export function defaultMcpResource(origin: string) {
 	return `${origin}${mcpResourcePath}`
 }
 
+export function canonicalizeAudience(value: string) {
+	return value.replace(/\/+$/, '')
+}
+
 export function audienceMatches(
 	audience: string | Array<string> | undefined,
 	origin: string,
 ) {
-	const expected = defaultMcpResource(origin)
 	if (audience === undefined) return true
-	if (typeof audience === 'string') {
-		return audience === expected || audience === origin
-	}
-	return audience.includes(expected) || audience.includes(origin)
+	const base = canonicalizeAudience(origin)
+	const allowed = new Set([
+		base,
+		`${base}${mcpResourcePath}`,
+		`${base}${apiResourcePath}`,
+	])
+	const values = typeof audience === 'string' ? [audience] : audience
+	return values.some((value) => allowed.has(canonicalizeAudience(value)))
 }
 
 export async function userFromGrantProps(

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from 'vitest'
 import { handleRequest } from '#src/index.ts'
 import { oauthPaths } from '#src/oauth-paths.ts'
-import { type OAuthAuthRequest, type OAuthHelpers } from '#src/oauth-user.ts'
+import {
+	audienceMatches,
+	type OAuthAuthRequest,
+	type OAuthHelpers,
+} from '#src/oauth-user.ts'
 import {
 	createSignedInUser,
 	createTestEnv,
@@ -40,6 +44,21 @@ function mockHelpers(
 		...overrides,
 	}
 }
+
+test('audienceMatches accepts origin, /mcp, /api, and trailing slashes', () => {
+	const origin = 'https://kody.exchange'
+	expect(audienceMatches(undefined, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/mcp`, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/mcp/`, origin)).toBe(true)
+	expect(audienceMatches(origin, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/`, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/api`, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/api/`, origin)).toBe(true)
+	expect(audienceMatches([`${origin}/`], origin)).toBe(true)
+	expect(audienceMatches([`${origin}/api`], origin)).toBe(true)
+	expect(audienceMatches(`${origin}/other`, origin)).toBe(false)
+	expect(audienceMatches(['https://example.com'], origin)).toBe(false)
+})
 
 test('protected resource metadata advertises /mcp', async () => {
 	const env = createTestEnv()

--- a/src/worker.node.test.ts
+++ b/src/worker.node.test.ts
@@ -64,5 +64,5 @@ test('worker fetch serves /mcp on the root PRM OAuthProvider would own', async (
 		ctx,
 	)
 	const apiBody = (await apiPath.json()) as { resource: string }
-	expect(apiBody.resource).toBe('https://kody.exchange/mcp')
+	expect(apiBody.resource).toBe('https://kody.exchange/api')
 })

--- a/src/worker.node.test.ts
+++ b/src/worker.node.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest'
+import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
+import { oauthPaths, oauthScopes } from '#src/oauth-paths.ts'
+import { createTestEnv, request } from '#src/test-support.ts'
+import worker from '#src/worker.ts'
+
+function executionContext(): ExecutionContext {
+	return {
+		waitUntil() {},
+		passThroughOnException() {},
+		props: {},
+	} as unknown as ExecutionContext
+}
+
+test('worker fetch serves /mcp on the root PRM OAuthProvider would own', async () => {
+	const env = createTestEnv()
+	const ctx = executionContext()
+	const provider = new OAuthProvider({
+		apiRoute: oauthPaths.apiPrefix,
+		apiHandler: {
+			fetch() {
+				return new Response('api')
+			},
+		},
+		defaultHandler: {
+			fetch() {
+				return new Response('default')
+			},
+		},
+		authorizeEndpoint: oauthPaths.authorize,
+		tokenEndpoint: oauthPaths.token,
+		clientRegistrationEndpoint: oauthPaths.register,
+		scopesSupported: [...oauthScopes],
+	})
+
+	const throughProvider = await provider.fetch(
+		request(oauthPaths.protectedResource),
+		env,
+		ctx,
+	)
+	const providerBody = (await throughProvider.json()) as { resource: string }
+	expect(providerBody.resource).toBe('https://kody.exchange')
+
+	const throughWorker = await worker.fetch(
+		request(oauthPaths.protectedResource),
+		env,
+		ctx,
+	)
+	expect(throughWorker.status).toBe(200)
+	const workerBody = (await throughWorker.json()) as { resource: string }
+	expect(workerBody.resource).toBe('https://kody.exchange/mcp')
+
+	const pathBased = await worker.fetch(
+		request(`${oauthPaths.protectedResource}${oauthPaths.mcp}`),
+		env,
+		ctx,
+	)
+	const pathBody = (await pathBased.json()) as { resource: string }
+	expect(pathBody.resource).toBe('https://kody.exchange/mcp')
+
+	const apiPath = await worker.fetch(
+		request(`${oauthPaths.protectedResource}/api`),
+		env,
+		ctx,
+	)
+	const apiBody = (await apiPath.json()) as { resource: string }
+	expect(apiBody.resource).toBe('https://kody.exchange/mcp')
+})

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,8 +2,15 @@ import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
 import { ThreadRoom } from '#src/thread-room.ts'
 import { handleRequest } from '#src/index.ts'
 import { type AppEnv } from '#src/env.ts'
-import { oauthPaths, oauthScopes } from '#src/oauth-paths.ts'
-import { userFromGrantProps } from '#src/oauth-user.ts'
+import {
+	isProtectedResourceMetadataPath,
+	oauthPaths,
+	oauthScopes,
+} from '#src/oauth-paths.ts'
+import {
+	handleProtectedResourceMetadata,
+	userFromGrantProps,
+} from '#src/oauth-user.ts'
 import { purgeExpired } from '#src/threads.ts'
 import { handleUserApi } from '#src/user-api.ts'
 
@@ -43,6 +50,14 @@ export { ThreadRoom }
 
 export default {
 	fetch(request: Request, env: AppEnv, ctx: ExecutionContext) {
+		// OAuthProvider serves this URL first and defaults `resource` to the
+		// origin only. MCP clients follow RFC 9728 from WWW-Authenticate and
+		// must see `<origin>/mcp` on the root PRM, or the token audience fails
+		// and Kody stays "authenticating".
+		const pathname = new URL(request.url).pathname
+		if (isProtectedResourceMetadataPath(pathname)) {
+			return handleProtectedResourceMetadata(request, env)
+		}
 		return oauthProvider.fetch(request, env, ctx)
 	},
 	async scheduled(_event: ScheduledEvent, env: AppEnv) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,9 +4,21 @@ export default defineConfig({
 	test: {
 		include: ['src/**/*.node.test.ts', 'tools/**/*.node.test.ts'],
 		environment: 'node',
+		server: {
+			deps: {
+				inline: ['@cloudflare/workers-oauth-provider'],
+			},
+		},
 	},
 	resolve: {
 		alias: [
+			{
+				find: 'cloudflare:workers',
+				replacement: new URL(
+					'./src/cloudflare-workers-node.ts',
+					import.meta.url,
+				).pathname,
+			},
 			{
 				find: '#src/og-assets.ts',
 				replacement: new URL('./src/og-assets.node.ts', import.meta.url)


### PR DESCRIPTION
## Why

`mcp_server_add` against `https://kody.exchange/mcp` stays **authenticating** after consent. The Agents SDK follows RFC 9728 from `WWW-Authenticate` to the **root** PRM. `@cloudflare/workers-oauth-provider` intercepts that path and defaults `resource` to the origin. Tokens then fail `audienceMatches` (`https://kody.exchange/` ≠ `/mcp`), so `/mcp` stays 401.

This is the same class of bug kody.codes already fixed by serving PRM **before** `oauthProvider.fetch()`.

## What changed

- `src/worker.ts` serves root and path-based `/.well-known/oauth-protected-resource` before the provider. `resource` is `https://kody.exchange/mcp`.
- `audienceMatches` canonicalizes trailing slashes and accepts origin, `/mcp`, and `/api`.
- Worker-entry test calls `oauthProvider.fetch()` (origin-only) and the worker default export (`/mcp`). `handleRequest` alone is not treated as sufficient.
- Local wrangler already returns `/mcp`. Production still returns the origin until this deploys.

## Risk

Medium. OAuth discovery / token audience. No guest `/v1` change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/mcp-oauth-prm-8f73`

**Classification:** extends — production entry now owns protected-resource metadata that OAuthProvider used to serve as origin-only.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| Agent token | credentials | extends — accepted OAuth audiences include slash-canonical origin, `/mcp`, and `/api` |

### System map

MCP clients discover the root PRM from WWW-Authenticate. The worker answers that document before the OAuth provider.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  mcpClient["mcp-client<br/>Kody MCP add"]:::untouched
  workerFetch["worker-fetch<br/>Production entry"]:::extended
  oauthProvider["oauth-provider<br/>workers-oauth-provider"]:::untouched
  mcpClient -->|"GET /.well-known/oauth-protected-resource"| workerFetch
  workerFetch -->|"resource https://kody.exchange/mcp"| mcpClient
  workerFetch -->|"all other OAuth routes"| oauthProvider
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth discovery and token audience validation on the production worker entrypoint; guest `/v1` is unchanged.
> 
> **Overview**
> Fixes MCP clients stuck **authenticating** after OAuth consent by answering **root** `/.well-known/oauth-protected-resource` in the production worker **before** `OAuthProvider`, so `resource` is `https://kody.exchange/mcp` instead of the provider’s origin-only default.
> 
> Adds `isProtectedResourceMetadataPath` for the root PRM and `…/mcp` only (path-based `…/api` PRM still goes through the provider). **`audienceMatches`** now canonicalizes trailing slashes and accepts origin, `/mcp`, and `/api`. Docs record the invariant; **Vitest** gets a `cloudflare:workers` stub, inlines the OAuth provider package, and a worker test contrasts provider vs worker PRM responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baaa24f0de972894293cfd6cba0861eb9c67eee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->