### PR TITLE
fix: accept Kody MCP OAuth resource audiences

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,10 @@ import {
 	mcpBrowserLanding,
 } from '#src/mcp.ts'
 import { handleAuthorizeRequest } from '#src/oauth-authorize.ts'
-import { oauthPaths } from '#src/oauth-paths.ts'
+import {
+	isProtectedResourceMetadataRequest,
+	oauthPaths,
+} from '#src/oauth-paths.ts'
 import {
 	handleProtectedResourceMetadata,
 	resolveOAuthUser,
@@ -91,10 +94,7 @@ export async function handleRequest(
 		return logoutResponse()
 	}
 
-	if (url.pathname === oauthPaths.protectedResource) {
-		return handleProtectedResourceMetadata(request, env)
-	}
-	if (url.pathname === `${oauthPaths.protectedResource}${oauthPaths.mcp}`) {
+	if (isProtectedResourceMetadataRequest(url.pathname)) {
 		return handleProtectedResourceMetadata(request, env)
 	}
 	if (url.pathname === oauthPaths.authorize) {

--- a/src/oauth-paths.ts
+++ b/src/oauth-paths.ts
@@ -11,5 +11,13 @@ export const oauthPaths = {
 export const oauthScopes = ['profile', 'threads'] as const
 
 export const mcpResourcePath = '/mcp'
+export const apiResourcePath = '/api'
 export const protectedResourceMetadataPath =
 	'/.well-known/oauth-protected-resource'
+
+export function isProtectedResourceMetadataRequest(pathname: string) {
+	return (
+		pathname === protectedResourceMetadataPath ||
+		pathname === `${protectedResourceMetadataPath}${mcpResourcePath}`
+	)
+}

--- a/src/oauth-user.ts
+++ b/src/oauth-user.ts
@@ -3,6 +3,7 @@ import { first } from '#src/db.ts'
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
 import { freeAccountUpsell } from '#src/free-account.ts'
 import {
+	apiResourcePath,
 	mcpResourcePath,
 	oauthScopes,
 	protectedResourceMetadataPath,
@@ -69,7 +70,7 @@ export function handleProtectedResourceMetadata(request: Request, env: AppEnv) {
 }
 
 export function unauthorizedOAuthResponse(origin: string) {
-	const resourceMetadata = `${origin}${protectedResourceMetadataPath}`
+	const resourceMetadata = `${origin}${protectedResourceMetadataPath}${mcpResourcePath}`
 	const scope = ` scope="${oauthScopes.join(' ')}"`
 	return json(
 		{
@@ -90,16 +91,22 @@ export function defaultMcpResource(origin: string) {
 	return `${origin}${mcpResourcePath}`
 }
 
+function stripTrailingSlash(value: string) {
+	return value.length > 1 && value.endsWith('/') ? value.slice(0, -1) : value
+}
+
 export function audienceMatches(
 	audience: string | Array<string> | undefined,
 	origin: string,
 ) {
-	const expected = defaultMcpResource(origin)
 	if (audience === undefined) return true
-	if (typeof audience === 'string') {
-		return audience === expected || audience === origin
-	}
-	return audience.includes(expected) || audience.includes(origin)
+	const allowed = new Set([
+		stripTrailingSlash(origin),
+		stripTrailingSlash(`${origin}${mcpResourcePath}`),
+		stripTrailingSlash(`${origin}${apiResourcePath}`),
+	])
+	const values = Array.isArray(audience) ? audience : [audience]
+	return values.some((value) => allowed.has(stripTrailingSlash(value)))
 }
 
 export async function userFromGrantProps(

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from 'vitest'
 import { handleRequest } from '#src/index.ts'
 import { oauthPaths } from '#src/oauth-paths.ts'
-import { type OAuthAuthRequest, type OAuthHelpers } from '#src/oauth-user.ts'
+import {
+	audienceMatches,
+	type OAuthAuthRequest,
+	type OAuthHelpers,
+	unauthorizedOAuthResponse,
+} from '#src/oauth-user.ts'
 import {
 	createSignedInUser,
 	createTestEnv,
@@ -41,6 +46,22 @@ function mockHelpers(
 	}
 }
 
+test('audienceMatches accepts the resource Kody MCP actually requests', () => {
+	const origin = 'https://kody.exchange'
+	expect(audienceMatches(`${origin}/`, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/mcp`, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/api`, origin)).toBe(true)
+	expect(audienceMatches(`${origin}/api/`, origin)).toBe(true)
+	expect(audienceMatches('https://evil.example/mcp', origin)).toBe(false)
+})
+
+test('MCP 401 points clients at the /mcp protected-resource document', () => {
+	const response = unauthorizedOAuthResponse('https://kody.exchange')
+	expect(response.headers.get('www-authenticate')).toContain(
+		'resource_metadata="https://kody.exchange/.well-known/oauth-protected-resource/mcp"',
+	)
+})
+
 test('protected resource metadata advertises /mcp', async () => {
 	const env = createTestEnv()
 	const response = await handleRequest(
@@ -70,7 +91,7 @@ test('unauthenticated MCP and /api return 401 with WWW-Authenticate', async () =
 	)
 	expect(mcp.status).toBe(401)
 	expect(mcp.headers.get('www-authenticate')).toContain(
-		'resource_metadata="https://kody.exchange/.well-known/oauth-protected-resource"',
+		'resource_metadata="https://kody.exchange/.well-known/oauth-protected-resource/mcp"',
 	)
 
 	const api = await handleRequest(request('/api/me'), env)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,8 +2,15 @@ import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
 import { ThreadRoom } from '#src/thread-room.ts'
 import { handleRequest } from '#src/index.ts'
 import { type AppEnv } from '#src/env.ts'
-import { oauthPaths, oauthScopes } from '#src/oauth-paths.ts'
-import { userFromGrantProps } from '#src/oauth-user.ts'
+import {
+	isProtectedResourceMetadataRequest,
+	oauthPaths,
+	oauthScopes,
+} from '#src/oauth-paths.ts'
+import {
+	handleProtectedResourceMetadata,
+	userFromGrantProps,
+} from '#src/oauth-user.ts'
 import { purgeExpired } from '#src/threads.ts'
 import { handleUserApi } from '#src/user-api.ts'
 
@@ -43,6 +50,11 @@ export { ThreadRoom }
 
 export default {
 	fetch(request: Request, env: AppEnv, ctx: ExecutionContext) {
+		const url = new URL(request.url)
+		// OAuthProvider otherwise serves origin as the root PRM resource.
+		if (isProtectedResourceMetadataRequest(url.pathname)) {
+			return handleProtectedResourceMetadata(request, env)
+		}
 		return oauthProvider.fetch(request, env, ctx)
 	},
 	async scheduled(_event: ScheduledEvent, env: AppEnv) {


### PR DESCRIPTION
> [!WARNING]
> This was created by AI. I haven't reviewed it just yet. I did personally run into an issue trying to Oauth the Kody Exchange MCP. This solves that

## Summary
- Serve `/mcp` protected-resource metadata before `@cloudflare/workers-oauth-provider` so production matches the docs (the provider was advertising origin).
- Point MCP 401 `WWW-Authenticate` at `/.well-known/oauth-protected-resource/mcp`.
- Accept origin, `/mcp`, and `/api` audiences with or without a trailing slash so Kody MCP clients stop staying on Authorization required after consent.

## Test plan
- [x] `npx vitest run src/oauth.node.test.ts`
- [ ] After deploy: add `https://kody.exchange/mcp` in Kody MCP servers, complete consent, confirm state is ready and `kody.mcp["kody-exchange"]` tools appear
- [ ] Existing `/api` OAuth (`exchange-threads` list/create) still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for protected-resource metadata discovery at the root, `/mcp`, and `/api` resource paths.
  - OAuth-protected requests now advertise the appropriate metadata document, including the MCP-specific endpoint.
  - Resource audience validation now accepts matching origin, MCP, and API resource URLs, including trailing-slash variations.

- **Bug Fixes**
  - Improved handling of OAuth metadata requests across supported resource paths.
  - Correctly rejects tokens intended for unrelated resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->