### PR TITLE
Research page Open Graph image

### DIFF
--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from 'vitest'
+import { first } from '#src/db.ts'
+import { researchOgImage, researchOgImageAlt } from '#src/html.ts'
 import { handleRequest } from '#src/index.ts'
 import { createTestEnv, request } from '#src/test-support.ts'
 import { liveTokenFor } from '#src/threads.ts'
-import { first } from '#src/db.ts'
 
 test('guest thread: create, join, send, poll, and health', async () => {
 	const env = createTestEnv()
@@ -437,6 +438,11 @@ test('pricing page explains live threads and participants', async () => {
 	expect(researchHtml).toContain('kx_join_')
 	expect(researchHtml).toContain('How to cite')
 	expect(researchHtml).toContain('>Research<')
+	expect(researchHtml).toContain(
+		`content="https://kody.exchange${researchOgImage}"`,
+	)
+	expect(researchHtml).toContain(`content="${researchOgImageAlt}"`)
+	expect(researchHtml).not.toContain('content="https://kody.exchange/og.png"')
 	expect(researchHtml).not.toContain('Max')
 	expect(researchHtml).not.toMatch(/kx_view_[0-9a-f]{16,}/)
 	expect(researchHtml).not.toMatch(/kx_join_[0-9a-f]{16,}/)

--- a/src/html.ts
+++ b/src/html.ts
@@ -24,6 +24,13 @@ export function escapeHtml(value: string) {
 		.replaceAll("'", '&#39;')
 }
 
+export const defaultOgImage = '/og.png'
+export const defaultOgImageAlt =
+	'kody.exchange — Ephemeral chatrooms for agents'
+export const researchOgImage = '/research/og.png'
+export const researchOgImageAlt =
+	'kody.exchange research — Peer-channel security and privacy. 261 turns, 6 live rooms, 0 leaks.'
+
 export function layout(input: {
 	title: string
 	description?: string
@@ -33,6 +40,8 @@ export function layout(input: {
 	body: string
 	extraHead?: string
 	mainClass?: string
+	ogImage?: string
+	ogImageAlt?: string
 }) {
 	const origin = (input.env.APP_BASE_URL ?? 'https://kody.exchange').replace(
 		/\/$/,
@@ -42,6 +51,9 @@ export function layout(input: {
 		? input.title
 		: `${input.title} · kody.exchange`
 	const description = input.description ?? siteDescription
+	const ogImagePath = input.ogImage ?? defaultOgImage
+	const ogImageUrl = `${origin}${ogImagePath}`
+	const ogImageAlt = input.ogImageAlt ?? defaultOgImageAlt
 	const signedIn = Boolean(input.user)
 	return `<!doctype html>
 <html lang="en">
@@ -52,14 +64,14 @@ export function layout(input: {
 	<meta name="description" content="${escapeHtml(description)}" />
 	<meta property="og:title" content="${escapeHtml(title)}" />
 	<meta property="og:description" content="${escapeHtml(description)}" />
-	<meta property="og:image" content="${escapeHtml(origin)}/og.png" />
+	<meta property="og:image" content="${escapeHtml(ogImageUrl)}" />
 	<meta property="og:image:type" content="image/png" />
 	<meta property="og:image:width" content="1200" />
 	<meta property="og:image:height" content="630" />
-	<meta property="og:image:alt" content="kody.exchange — Ephemeral chatrooms for agents" />
+	<meta property="og:image:alt" content="${escapeHtml(ogImageAlt)}" />
 	<meta property="og:url" content="${escapeHtml(origin)}${escapeHtml(input.path)}" />
 	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:image" content="${escapeHtml(origin)}/og.png" />
+	<meta name="twitter:image" content="${escapeHtml(ogImageUrl)}" />
 	<meta name="color-scheme" content="light dark" />
 	<meta name="theme-color" content="#f6efe3" media="(prefers-color-scheme: light)" />
 	<meta name="theme-color" content="#1a1612" media="(prefers-color-scheme: dark)" />

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,14 @@ export async function handleRequest(
 		return ogImageResponse(env)
 	}
 
+	if (
+		url.pathname === '/research/og.png' ||
+		url.pathname === '/research/og.jpg'
+	) {
+		const { ogImageResponse } = await import('#src/og.ts')
+		return ogImageResponse(env, 'research')
+	}
+
 	if (request.method === 'POST' && url.pathname === '/webhooks/stripe') {
 		return stripeWebhook(request, env)
 	}

--- a/src/og.node.test.ts
+++ b/src/og.node.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from 'vitest'
 import { handleRequest } from '#src/index.ts'
 import {
 	createOgMarkup,
+	createResearchOgMarkup,
 	findOgIconElement,
 	loadIconDataUri,
 	OG_HEIGHT,
@@ -13,7 +14,14 @@ import {
 	OG_TAGLINE,
 	OG_WIDTH,
 	OG_WORDMARK,
+	RESEARCH_OG_ICON_SIZE,
+	RESEARCH_OG_STAMP,
+	RESEARCH_OG_STATS,
+	RESEARCH_OG_TITLE,
+	RESEARCH_OG_TITLE_LINE_1,
+	RESEARCH_OG_TITLE_LINE_2,
 	renderExchangeOgImage,
+	renderResearchOgImage,
 } from '#src/og.ts'
 import { createTestEnv, request } from '#src/test-support.ts'
 
@@ -93,6 +101,48 @@ test('renderExchangeOgImage returns a 1200×630 PNG', async () => {
 	expectPngCard(png)
 })
 
+test('research OG markup is a report card, not the homepage mark', () => {
+	const markup = createResearchOgMarkup('data:image/png;base64,abc')
+	const icon = findOgIconElement(markup)
+	expect(icon).not.toBeNull()
+	expect(RESEARCH_OG_ICON_SIZE).toBeLessThan(OG_HEIGHT)
+	expect(icon?.props.width).toBe(RESEARCH_OG_ICON_SIZE)
+	expect(icon?.props.height).toBe(RESEARCH_OG_ICON_SIZE)
+	expect(markup.props.style?.alignItems).not.toBe('flex-end')
+
+	const tree = JSON.stringify(markup)
+	expect(tree).toContain(RESEARCH_OG_STAMP)
+	expect(tree).toContain(RESEARCH_OG_TITLE_LINE_1)
+	expect(tree).toContain(RESEARCH_OG_TITLE_LINE_2)
+	expect(RESEARCH_OG_TITLE).toBe(
+		`${RESEARCH_OG_TITLE_LINE_1} ${RESEARCH_OG_TITLE_LINE_2}`,
+	)
+	expect(tree).toContain(OG_WORDMARK)
+	expect(tree).not.toContain(OG_TAGLINE)
+	for (const stat of RESEARCH_OG_STATS) {
+		expect(tree).toContain(stat.value)
+		expect(tree).toContain(stat.label)
+	}
+	expect(tree).toContain('#d4921a')
+	expect(tree).toContain('#b54a3c')
+	expect(tree).toContain('#fffaf1')
+})
+
+test('renderResearchOgImage returns a 1200×630 PNG', async () => {
+	const env = createTestEnv()
+	await env.BLOBS.put(
+		'public/icon.png',
+		publicIcon.buffer.slice(
+			publicIcon.byteOffset,
+			publicIcon.byteOffset + publicIcon.byteLength,
+		),
+		{ httpMetadata: { contentType: 'image/png' } },
+	)
+	const png = await renderResearchOgImage(env)
+	expect(png.byteLength).toBeGreaterThan(10_000)
+	expectPngCard(png)
+})
+
 test('/og.png and /og.jpg both render the Satori card', async () => {
 	const env = createTestEnv()
 	const png = await handleRequest(request('/og.png'), env)
@@ -101,6 +151,19 @@ test('/og.png and /og.jpg both render the Satori card', async () => {
 	expectPngCard(new Uint8Array(await png.arrayBuffer()))
 
 	const legacy = await handleRequest(request('/og.jpg'), env)
+	expect(legacy.status).toBe(200)
+	expect(legacy.headers.get('content-type')).toBe('image/png')
+	expectPngCard(new Uint8Array(await legacy.arrayBuffer()))
+})
+
+test('/research/og.png and /research/og.jpg both render the research card', async () => {
+	const env = createTestEnv()
+	const png = await handleRequest(request('/research/og.png'), env)
+	expect(png.status).toBe(200)
+	expect(png.headers.get('content-type')).toBe('image/png')
+	expectPngCard(new Uint8Array(await png.arrayBuffer()))
+
+	const legacy = await handleRequest(request('/research/og.jpg'), env)
 	expect(legacy.status).toBe(200)
 	expect(legacy.headers.get('content-type')).toBe('image/png')
 	expectPngCard(new Uint8Array(await legacy.arrayBuffer()))

--- a/src/og.ts
+++ b/src/og.ts
@@ -20,8 +20,24 @@ export const OG_WORDMARK = 'kody.exchange'
 export const OG_TAGLINE = 'Ephemeral chatrooms for agents'
 
 const PAPER = '#f6efe3'
+const CARD = '#fffaf1'
 const INK = '#1c1610'
 const MUTED = '#6b5e4e'
+const AMBER = '#d4921a'
+const STAMP = '#b54a3c'
+const LINE = '#d7cbb6'
+
+export const RESEARCH_OG_ICON_SIZE = 72
+export const RESEARCH_OG_STAMP = 'Technical report  ·  15 August 2026'
+export const RESEARCH_OG_TITLE_LINE_1 = 'Peer-channel security'
+export const RESEARCH_OG_TITLE_LINE_2 = 'and privacy'
+export const RESEARCH_OG_TITLE = `${RESEARCH_OG_TITLE_LINE_1} ${RESEARCH_OG_TITLE_LINE_2}`
+export const RESEARCH_OG_STATS = [
+	{ value: '261', label: 'turns' },
+	{ value: '6', label: 'live rooms' },
+	{ value: '0', label: 'leaks' },
+] as const
+export type OgCard = 'exchange' | 'research'
 
 export type SatoriChild = string | SatoriElement
 export type SatoriElement = {
@@ -167,6 +183,214 @@ export function createOgMarkup(iconDataUri: string): SatoriElement {
 	}
 }
 
+function researchStat(value: string, label: string): SatoriElement {
+	return {
+		type: 'div',
+		props: {
+			style: {
+				display: 'flex',
+				flexDirection: 'column',
+				width: 220,
+			},
+			children: [
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							fontFamily: 'Fraunces',
+							fontWeight: 700,
+							fontSize: 72,
+							lineHeight: 1,
+							letterSpacing: '-0.03em',
+							color: INK,
+						},
+						children: value,
+					},
+				},
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							marginTop: 8,
+							fontFamily: 'Source Serif 4',
+							fontWeight: 400,
+							fontSize: 26,
+							lineHeight: 1.2,
+							color: MUTED,
+						},
+						children: label,
+					},
+				},
+			],
+		},
+	}
+}
+
+export function createResearchOgMarkup(iconDataUri: string): SatoriElement {
+	return {
+		type: 'div',
+		props: {
+			style: {
+				width: OG_WIDTH,
+				height: OG_HEIGHT,
+				display: 'flex',
+				backgroundColor: PAPER,
+			},
+			children: [
+				{
+					type: 'div',
+					props: {
+						style: {
+							width: 16,
+							height: OG_HEIGHT,
+							flexShrink: 0,
+							backgroundColor: AMBER,
+						},
+					},
+				},
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							flexDirection: 'column',
+							justifyContent: 'space-between',
+							flexGrow: 1,
+							height: OG_HEIGHT,
+							padding: '52px 64px 44px 56px',
+							backgroundColor: CARD,
+						},
+						children: [
+							{
+								type: 'div',
+								props: {
+									style: {
+										display: 'flex',
+										flexDirection: 'column',
+									},
+									children: [
+										{
+											type: 'div',
+											props: {
+												style: {
+													display: 'flex',
+													alignSelf: 'flex-start',
+													borderWidth: 2,
+													borderStyle: 'dashed',
+													borderColor: STAMP,
+													color: STAMP,
+													padding: '8px 14px',
+													fontFamily: 'Source Serif 4',
+													fontWeight: 400,
+													fontSize: 22,
+													letterSpacing: '0.08em',
+												},
+												children: RESEARCH_OG_STAMP,
+											},
+										},
+										{
+											type: 'div',
+											props: {
+												style: {
+													display: 'flex',
+													flexDirection: 'column',
+													marginTop: 28,
+													fontFamily: 'Fraunces',
+													fontWeight: 700,
+													fontSize: 64,
+													lineHeight: 1.05,
+													letterSpacing: '-0.03em',
+													color: INK,
+												},
+												children: [
+													{
+														type: 'div',
+														props: {
+															style: { display: 'flex' },
+															children: RESEARCH_OG_TITLE_LINE_1,
+														},
+													},
+													{
+														type: 'div',
+														props: {
+															style: { display: 'flex' },
+															children: RESEARCH_OG_TITLE_LINE_2,
+														},
+													},
+												],
+											},
+										},
+									],
+								},
+							},
+							{
+								type: 'div',
+								props: {
+									style: {
+										display: 'flex',
+										flexDirection: 'row',
+										marginTop: 36,
+									},
+									children: RESEARCH_OG_STATS.map((stat) =>
+										researchStat(stat.value, stat.label),
+									),
+								},
+							},
+							{
+								type: 'div',
+								props: {
+									style: {
+										display: 'flex',
+										alignItems: 'center',
+										marginTop: 36,
+										paddingTop: 22,
+										borderTopWidth: 1,
+										borderTopStyle: 'solid',
+										borderTopColor: LINE,
+									},
+									children: [
+										{
+											type: 'img',
+											props: {
+												src: iconDataUri,
+												width: RESEARCH_OG_ICON_SIZE,
+												height: RESEARCH_OG_ICON_SIZE,
+												style: {
+													width: RESEARCH_OG_ICON_SIZE,
+													height: RESEARCH_OG_ICON_SIZE,
+													flexShrink: 0,
+													objectFit: 'contain',
+												},
+											},
+										},
+										{
+											type: 'div',
+											props: {
+												style: {
+													display: 'flex',
+													marginLeft: 14,
+													fontFamily: 'Fraunces',
+													fontWeight: 700,
+													fontSize: 28,
+													letterSpacing: '-0.02em',
+													color: INK,
+												},
+												children: OG_WORDMARK,
+											},
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+}
+
 export function findOgIconElement(markup: SatoriElement): SatoriElement | null {
 	if (markup.type === 'img') return markup
 	const children = markup.props.children
@@ -179,15 +403,15 @@ export function findOgIconElement(markup: SatoriElement): SatoriElement | null {
 	return null
 }
 
-export async function renderExchangeOgImage(
+async function renderOgPng(
 	env: AppEnv,
+	markup: SatoriElement,
 ): Promise<Uint8Array<ArrayBuffer>> {
 	await Promise.all([
 		ensureOgWasmReady(),
 		ensureOgFontsReady({ assets: env.ASSETS }),
 	])
 
-	const markup = createOgMarkup(await loadIconDataUri(env))
 	const displayFont = getFraunces700FontData()
 	const bodyFont = getSourceSerif400FontData()
 	const svg = await satori(markup, {
@@ -224,12 +448,39 @@ export async function renderExchangeOgImage(
 	return png as Uint8Array<ArrayBuffer>
 }
 
-export async function ogImageResponse(env: AppEnv): Promise<Response> {
-	const png = await renderExchangeOgImage(env)
+function pngImageResponse(png: Uint8Array<ArrayBuffer>): Response {
 	return new Response(png, {
 		headers: {
 			'content-type': 'image/png',
 			'cache-control': 'public, max-age=3600',
 		},
 	})
+}
+
+export async function renderExchangeOgImage(
+	env: AppEnv,
+): Promise<Uint8Array<ArrayBuffer>> {
+	return renderOgPng(env, createOgMarkup(await loadIconDataUri(env)))
+}
+
+export async function renderResearchOgImage(
+	env: AppEnv,
+): Promise<Uint8Array<ArrayBuffer>> {
+	return renderOgPng(env, createResearchOgMarkup(await loadIconDataUri(env)))
+}
+
+export async function ogImageResponse(
+	env: AppEnv,
+	card: OgCard = 'exchange',
+): Promise<Response> {
+	switch (card) {
+		case 'exchange':
+			return pngImageResponse(await renderExchangeOgImage(env))
+		case 'research':
+			return pngImageResponse(await renderResearchOgImage(env))
+		default: {
+			const exhaustive: never = card
+			throw new Error(`unknown OG card: ${exhaustive}`)
+		}
+	}
 }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -24,6 +24,8 @@ import {
 	pricingPage,
 	privacyPage,
 	promptCard,
+	researchOgImage,
+	researchOgImageAlt,
 	termsPage,
 	threadNotFoundPage,
 	threadViewPage,
@@ -101,6 +103,8 @@ export async function renderPage(
 					title: 'Research',
 					description:
 						'Peer-channel security and privacy on kody.exchange — method, scores, and what a watch link grants.',
+					ogImage: researchOgImage,
+					ogImageAlt: researchOgImageAlt,
 					body: researchPage(),
 				}),
 			)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/research` now has its own Open Graph card so shares do not reuse the homepage mark.

The card is a 1200×630 technical-report layout in the site paper family: amber bar, dashed stamp, Fraunces title, the study stats (261 turns · 6 live rooms · 0 leaks), and a small Kody wordmark. It is generated with the same Satori + resvg path as `/og.png`.

![Research Open Graph card](https://cursor.com/artifacts/c/art-6068be89-4e06-4873-a9eb-384614ad3491)

- Served at `/research/og.png` (and `/research/og.jpg` for the same PNG)
- `layout()` accepts optional `ogImage` / `ogImageAlt`; other pages still use `/og.png`
- Homepage card is unchanged

`npm run validate` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60b426ae-3c32-441a-b5ba-063b25cba632?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60b426ae-3c32-441a-b5ba-063b25cba632&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

