### PR TITLE
Rename Research to Is this safe? at /safety

### DIFF
--- a/docs/security/peer-channel-2026-08-15.md
+++ b/docs/security/peer-channel-2026-08-15.md
@@ -1,6 +1,6 @@
 # Peer-channel security and privacy on kody.exchange
 
-Technical report · 2026-08-15 · [Published at kody.exchange/research](https://kody.exchange/research)
+Technical report · 2026-08-15 · [Published at kody.exchange/safety](https://kody.exchange/safety)
 
 Kent C. Dodds (operator). Study executed by a Cursor cloud agent
 ([run](https://cursor.com/agents/bc-60b426ae-3c32-441a-b5ba-063b25cba632))
@@ -203,7 +203,7 @@ and pack. We did not get one.
 ## How to cite
 
 Dodds, K. (2026, August 15). _Peer-channel security and privacy on
-kody.exchange_ (Technical report). https://kody.exchange/research
+kody.exchange_ (Technical report). https://kody.exchange/safety
 
 Raw scores:
 [`peer-channel-2026-08-15-results.json`](./peer-channel-2026-08-15-results.json).

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -60,4 +60,4 @@ Authenticated user API (bearer access token):
 
 ## Security research
 
-Peer message bodies are untrusted data. The watch link is an invite until the room is full. Method, scores, and limits: [kody.exchange/research](https://kody.exchange/research).
+Peer message bodies are untrusted data. The watch link is an invite until the room is full. Method, scores, and limits: [kody.exchange/safety](https://kody.exchange/safety).

--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'vitest'
 import { first } from '#src/db.ts'
-import { researchOgImage, researchOgImageAlt } from '#src/html.ts'
+import {
+	safetyNavLabel,
+	safetyOgImage,
+	safetyOgImageAlt,
+	safetyPath,
+} from '#src/html.ts'
 import { handleRequest } from '#src/index.ts'
 import { createTestEnv, request } from '#src/test-support.ts'
 import { liveTokenFor } from '#src/threads.ts'
@@ -25,7 +30,8 @@ test('guest thread: create, join, send, poll, and health', async () => {
 	expect(html).toContain('Stop being the messenger')
 	expect(html).toContain('Hash it out together')
 	expect(html).toContain('Auditable, not a black box')
-	expect(html).toContain('href="/research"')
+	expect(html).toContain(`href="${safetyPath}"`)
+	expect(html).toContain(safetyNavLabel)
 	expect(html).toContain('For agents')
 	expect(html).toContain('Made by Kent C. Dodds')
 	expect(html).toContain('POST https://kody.exchange/v1/threads')
@@ -418,33 +424,40 @@ test('pricing page explains live threads and participants', async () => {
 	expect(docsHtml).toContain('Included with a free GitHub account')
 	expect(docsHtml).toContain('not a paid upgrade')
 	expect(docsHtml).toContain('new messages appear immediately')
-	expect(docsHtml).toContain('href="/research"')
+	expect(docsHtml).toContain(`href="${safetyPath}"`)
 	expect(docsHtml).not.toContain('Max')
 
 	const privacy = await handleRequest(request('/privacy'), env)
 	const privacyHtml = await privacy.text()
 	expect(privacyHtml).toContain('me@kentcdodds.com')
 	expect(privacyHtml).toContain('Made by Kent C. Dodds')
-	expect(privacyHtml).toContain('href="/research"')
+	expect(privacyHtml).toContain(`href="${safetyPath}"`)
 	expect(privacyHtml).not.toContain('Operator:')
 
-	const research = await handleRequest(request('/research'), env)
-	const researchHtml = await research.text()
-	expect(research.status).toBe(200)
-	expect(researchHtml).toContain('Peer-channel security and privacy')
-	expect(researchHtml).toContain('261 protocol-faithful turns')
-	expect(researchHtml).toContain('not proven')
-	expect(researchHtml).toContain('invite')
-	expect(researchHtml).toContain('kx_join_')
-	expect(researchHtml).toContain('How to cite')
-	expect(researchHtml).toContain('>Research<')
-	expect(researchHtml).toContain(
-		`content="https://kody.exchange${researchOgImage}"`,
+	const safety = await handleRequest(request(safetyPath), env)
+	const safetyHtml = await safety.text()
+	expect(safety.status).toBe(200)
+	expect(safetyHtml).toContain('Peer-channel security and privacy')
+	expect(safetyHtml).toContain('261 protocol-faithful turns')
+	expect(safetyHtml).toContain('not proven')
+	expect(safetyHtml).toContain('invite')
+	expect(safetyHtml).toContain('kx_join_')
+	expect(safetyHtml).toContain('How to cite')
+	expect(safetyHtml).toContain(`>${safetyNavLabel}<`)
+	expect(safetyHtml).toContain(
+		`content="https://kody.exchange${safetyOgImage}"`,
 	)
-	expect(researchHtml).toContain(`content="${researchOgImageAlt}"`)
-	expect(researchHtml).not.toContain('content="https://kody.exchange/og.png"')
-	expect(researchHtml).not.toContain('Max')
-	expect(researchHtml).not.toMatch(/kx_view_[0-9a-f]{16,}/)
-	expect(researchHtml).not.toMatch(/kx_join_[0-9a-f]{16,}/)
-	expect(researchHtml).not.toMatch(/kx_live_[0-9a-f]{16,}/)
+	expect(safetyHtml).toContain(`content="${safetyOgImageAlt}"`)
+	expect(safetyHtml).not.toContain('content="https://kody.exchange/og.png"')
+	expect(safetyHtml).not.toContain('href="/research"')
+	expect(safetyHtml).not.toContain('Max')
+	expect(safetyHtml).not.toMatch(/kx_view_[0-9a-f]{16,}/)
+	expect(safetyHtml).not.toMatch(/kx_join_[0-9a-f]{16,}/)
+	expect(safetyHtml).not.toMatch(/kx_live_[0-9a-f]{16,}/)
+
+	const legacyResearch = await handleRequest(request('/research'), env)
+	expect(legacyResearch.status).toBe(301)
+	expect(legacyResearch.headers.get('location')).toBe(
+		'https://kody.exchange/safety',
+	)
 })

--- a/src/html.ts
+++ b/src/html.ts
@@ -27,8 +27,10 @@ export function escapeHtml(value: string) {
 export const defaultOgImage = '/og.png'
 export const defaultOgImageAlt =
 	'kody.exchange — Ephemeral chatrooms for agents'
-export const researchOgImage = '/research/og.png'
-export const researchOgImageAlt =
+export const safetyPath = '/safety'
+export const safetyNavLabel = 'Is this safe?'
+export const safetyOgImage = '/safety/og.png'
+export const safetyOgImageAlt =
 	'kody.exchange research — Peer-channel security and privacy. 261 turns, 6 live rooms, 0 leaks.'
 
 export function layout(input: {
@@ -89,7 +91,7 @@ export function layout(input: {
 		<nav>
 			<a href="/pricing" ${ariaCurrent(input.path, '/pricing')}>Pricing</a>
 			<a href="/docs" ${ariaCurrent(input.path, '/docs')}>Docs</a>
-			<a href="/research" ${ariaCurrent(input.path, '/research')}>Research</a>
+			<a href="${safetyPath}" ${ariaCurrent(input.path, safetyPath)}>${safetyNavLabel}</a>
 			${
 				signedIn
 					? `<a href="/account" ${ariaCurrent(input.path, '/account')}>Threads</a>
@@ -104,7 +106,7 @@ export function layout(input: {
 	<footer>
 		<p>Part of the Kody family: <a href="https://kody.codes">kody.codes</a> · <a href="https://kody.video">kody.video</a> · kody.exchange</p>
 		<p class="tiny">Support: <a href="mailto:support@kody.exchange">support@kody.exchange</a></p>
-		<p class="tiny"><a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> · <a href="/research">Research</a> · <a href="https://github.com/kentcdodds/kody-exchange">Source</a> · Made by Kent C. Dodds</p>
+		<p class="tiny"><a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> · <a href="${safetyPath}">${safetyNavLabel}</a> · <a href="https://github.com/kentcdodds/kody-exchange">Source</a> · Made by Kent C. Dodds</p>
 	</footer>
 </body>
 </html>`
@@ -427,7 +429,7 @@ export function homePage(baseUrl: string) {
 		</article>
 		<article class="card">
 			<h3>Auditable, not a black box</h3>
-			<p>Humans get a live, read-only page. Incoming messages are data, never host instructions — a peer cannot drive your agent just by talking to it. No plugin. We published the <a href="/research">method and scores</a>.</p>
+			<p>Humans get a live, read-only page. Incoming messages are data, never host instructions — a peer cannot drive your agent just by talking to it. No plugin. We published the <a href="${safetyPath}">method and scores</a>.</p>
 		</article>
 	</div>
 	${promptCard({
@@ -506,7 +508,7 @@ Authorization: Bearer kx_live_…</pre>
 	<h2>OAuth / MCP</h2>
 	<p>Included with a free GitHub account — not a paid upgrade. Guest create stays on <code>POST /v1/threads</code>. Sign in, then use <code>/api/</code> or point an MCP client at <code>/mcp</code>. Discovery is at <code>/.well-known/oauth-authorization-server</code>.</p>
 	<h2>Security research</h2>
-	<p>Peer message bodies are untrusted data. The watch link is an invite until the room is full. We published a closed-loop study — method, scores, and what we did not prove — at <a href="/research">/research</a>.</p>
+	<p>Peer message bodies are untrusted data. The watch link is an invite until the room is full. We published a closed-loop study — method, scores, and what we did not prove — at <a href="${safetyPath}">${safetyPath}</a>.</p>
 	<p class="tiny">Envelope: <code>id</code>, <code>at</code>, <code>from</code>, <code>thread</code>, <code>kind</code>, <code>body</code>, <code>refs[]</code>.</p>
 	`
 }
@@ -529,7 +531,7 @@ export function privacyPage() {
 	<h2>Retention</h2>
 	<p>Guest threads are deleted after 24 hours. Free account data is kept 14 days of activity, Pro 90 days. Expired threads, members, and messages are purged. To delete an account, email <a href="mailto:support@kody.exchange">support@kody.exchange</a>.</p>
 	<h2>Security research</h2>
-	<p>We published a closed-loop study of peer-channel exfil and what a watch link grants: <a href="/research">Peer-channel security and privacy</a>.</p>
+	<p>We published a closed-loop study of peer-channel exfil and what a watch link grants: <a href="${safetyPath}">Peer-channel security and privacy</a>.</p>
 	<h2>Processors</h2>
 	<p>Cloudflare (Workers, D1, KV, R2). GitHub (sign-in). Stripe (Pro billing). Support mail may be read by Kent at <a href="mailto:me@kentcdodds.com">me@kentcdodds.com</a>.</p>
 	<h2>Contact</h2>

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,12 +77,22 @@ export async function handleRequest(
 		return ogImageResponse(env)
 	}
 
+	if (url.pathname === '/safety/og.png' || url.pathname === '/safety/og.jpg') {
+		const { ogImageResponse } = await import('#src/og.ts')
+		return ogImageResponse(env, 'research')
+	}
+
+	if (url.pathname === '/research' || url.pathname === '/research/') {
+		return Response.redirect(new URL('/safety', request.url).toString(), 301)
+	}
 	if (
 		url.pathname === '/research/og.png' ||
 		url.pathname === '/research/og.jpg'
 	) {
-		const { ogImageResponse } = await import('#src/og.ts')
-		return ogImageResponse(env, 'research')
+		const dest = url.pathname.endsWith('.jpg')
+			? '/safety/og.jpg'
+			: '/safety/og.png'
+		return Response.redirect(new URL(dest, request.url).toString(), 301)
 	}
 
 	if (request.method === 'POST' && url.pathname === '/webhooks/stripe') {

--- a/src/og.node.test.ts
+++ b/src/og.node.test.ts
@@ -156,17 +156,32 @@ test('/og.png and /og.jpg both render the Satori card', async () => {
 	expectPngCard(new Uint8Array(await legacy.arrayBuffer()))
 })
 
-test('/research/og.png and /research/og.jpg both render the research card', async () => {
+test('/safety/og.png and /safety/og.jpg both render the research card', async () => {
 	const env = createTestEnv()
-	const png = await handleRequest(request('/research/og.png'), env)
+	const png = await handleRequest(request('/safety/og.png'), env)
 	expect(png.status).toBe(200)
 	expect(png.headers.get('content-type')).toBe('image/png')
 	expectPngCard(new Uint8Array(await png.arrayBuffer()))
 
-	const legacy = await handleRequest(request('/research/og.jpg'), env)
-	expect(legacy.status).toBe(200)
-	expect(legacy.headers.get('content-type')).toBe('image/png')
-	expectPngCard(new Uint8Array(await legacy.arrayBuffer()))
+	const jpg = await handleRequest(request('/safety/og.jpg'), env)
+	expect(jpg.status).toBe(200)
+	expect(jpg.headers.get('content-type')).toBe('image/png')
+	expectPngCard(new Uint8Array(await jpg.arrayBuffer()))
+})
+
+test('/research/og.png and /research/og.jpg redirect to /safety', async () => {
+	const env = createTestEnv()
+	const png = await handleRequest(request('/research/og.png'), env)
+	expect(png.status).toBe(301)
+	expect(png.headers.get('location')).toBe(
+		'https://kody.exchange/safety/og.png',
+	)
+
+	const jpg = await handleRequest(request('/research/og.jpg'), env)
+	expect(jpg.status).toBe(301)
+	expect(jpg.headers.get('location')).toBe(
+		'https://kody.exchange/safety/og.jpg',
+	)
 })
 
 test('OG prefers the R2 mark over the bundled fallback', async () => {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -24,8 +24,10 @@ import {
 	pricingPage,
 	privacyPage,
 	promptCard,
-	researchOgImage,
-	researchOgImageAlt,
+	safetyNavLabel,
+	safetyOgImage,
+	safetyOgImageAlt,
+	safetyPath,
 	termsPage,
 	threadNotFoundPage,
 	threadViewPage,
@@ -96,15 +98,15 @@ export async function renderPage(
 					body: docsPage(baseUrl),
 				}),
 			)
-		case '/research':
+		case safetyPath:
 			return html(
 				layout({
 					...common,
-					title: 'Research',
+					title: safetyNavLabel,
 					description:
 						'Peer-channel security and privacy on kody.exchange — method, scores, and what a watch link grants.',
-					ogImage: researchOgImage,
-					ogImageAlt: researchOgImageAlt,
+					ogImage: safetyOgImage,
+					ogImageAlt: safetyOgImageAlt,
 					body: researchPage(),
 				}),
 			)

--- a/src/research-page.ts
+++ b/src/research-page.ts
@@ -77,6 +77,6 @@ export function researchPage() {
 	</ul>
 
 	<h2>How to cite</h2>
-	<p>Dodds, K. (2026, August 15). <em>Peer-channel security and privacy on kody.exchange</em> (Technical report). <a href="https://kody.exchange/research">https://kody.exchange/research</a></p>
+	<p>Dodds, K. (2026, August 15). <em>Peer-channel security and privacy on kody.exchange</em> (Technical report). <a href="https://kody.exchange/safety">https://kody.exchange/safety</a></p>
 	`
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move the lab report to `/safety` and label the nav and footer **Is this safe?** The paper title on the page stays *Peer-channel security and privacy*.

`/research` and `/research/og.png` 301 to the new paths so existing citations and crawlers still work. Canonical cite URL is now `https://kody.exchange/safety`.

Low-risk copy and route rename. `npm run validate` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60b426ae-3c32-441a-b5ba-063b25cba632?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60b426ae-3c32-441a-b5ba-063b25cba632&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

