### PR TITLE
Allowlist Cursor Cloud Agent authors on the CLA check

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -2,8 +2,15 @@
 	"version": 1,
 	"document": "docs/legal/individual-cla.md",
 	"allowlist": {
-		"github": ["kentcdodds", "kody-bot"],
-		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
+		"github": [
+			"kentcdodds",
+			"kody-bot",
+			"cursoragent"
+		],
+		"email": [
+			"me@kentcdodds.com",
+			"me+github@kentcdodds.com"
+		]
 	},
 	"signers": []
 }

--- a/docs/contributing/decisions/0001-inbound-cla.md
+++ b/docs/contributing/decisions/0001-inbound-cla.md
@@ -36,7 +36,7 @@ How it works:
 
 - **Scope.** This git repository only.
 - **Who signs.** Every GitHub identity that authors a commit on the pull
-  request, unless that identity is `kentcdodds`, `kody-bot`, a `*[bot]`
+  request, unless that identity is `kentcdodds`, `kody-bot`, `cursoragent`, a `*[bot]`
   or `app/*` account, or an email listed as Licensor-owned in
   [`.github/cla-signers.json`](../../../.github/cla-signers.json).
 - **Which form.** [Individual CLA](../../legal/individual-cla.md) by default.

--- a/docs/contributing/inbound-contributions.md
+++ b/docs/contributing/inbound-contributions.md
@@ -1,7 +1,7 @@
 # Inbound contributions
 
 How outside patches enter [Kody Exchange](https://github.com/kentcdodds/kody-exchange).
-The decision and the why live in [0001 — Inbound CLA](./decisions/0001-inbound-cla.md).
+The decision and the why live in [0001 â Inbound CLA](./decisions/0001-inbound-cla.md).
 
 ## What needs a CLA
 
@@ -59,11 +59,12 @@ sign:
 
 - `kentcdodds` (Licensor)
 - `kody-bot` and other logins listed in that file
+- `cursoragent` (Cursor Cloud Agent commit author)
 - Licensor-owned commit emails listed in that file
 - GitHub accounts whose login ends in `[bot]` or starts with `app/`
 
-Cursor Cloud Agent pull requests that GitHub authors as `kentcdodds` follow
-the Licensor path.
+Cursor Cloud Agent pull requests follow the Licensor path even when GitHub
+authors the pull request as `kentcdodds` and the commits as `cursoragent`.
 
 ## Maintainer steps
 

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -12,6 +12,7 @@ test('CLA check allowlists the Licensor and signed humans, and rejects everyone 
 			[
 				{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
 				{ githubLogin: 'kody-bot', name: 'Kody', email: null },
+				{ githubLogin: 'cursoragent', name: 'Cursor Agent', email: 'cursoragent@cursor.com' },
 				{ githubLogin: 'cursor[bot]', name: 'cursor[bot]', email: null },
 			],
 			file,


### PR DESCRIPTION
Cloud Agent PRs are opened as `kentcdodds` but commits are authored as `cursoragent`. That identity is Licensor automation, not an outside contributor.

Matches kentcdodds/kody#1463.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and documentation only; CLA enforcement behavior changes only for the new allowlisted identity, with no impact on external contributors.
> 
> **Overview**
> **Cursor Cloud Agent** commits are authored as `cursoragent` while PRs may still appear under `kentcdodds`. This change treats that login as Licensor automation so the **CLA** workflow does not block those PRs.
> 
> `cursoragent` is added to the GitHub allowlist in `.github/cla-signers.json`. Contributing docs (ADR **0001** and **inbound-contributions**) now list `cursoragent` alongside existing bot/Licensor exceptions and clarify the Licensor path when commit author and PR opener differ. The CLA unit test asserts `cursoragent` passes the allowlist check with the real signers file.
> 
> No changes to `check-cla.mjs` logic—the existing allowlist lookup picks up the new entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2d974d0cd48e5b37e960112a75c283f8692de0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and licensing guidance to clarify how automated pull requests are handled.
  * Added the relevant automated contributor identity to the approved signer information.
  * Improved formatting and clarity of the contribution decision references.

* **Tests**
  * Added coverage to verify the approved automated contributor identity is recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->