### PR TITLE
Give every public page its own OG card, including live view rooms

### DIFF
--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -262,6 +262,13 @@ test('guest thread: create, join, send, poll, and health', async () => {
 	expect(viewHtml).not.toContain('name="body"')
 	expect(viewHtml).not.toMatch(/<textarea/)
 	expect(viewHtml).not.toContain('action="/v1/threads')
+	expect(viewHtml).toContain(
+		`content="https://kody.exchange${viewPath}/og.png"`,
+	)
+	expect(viewHtml).toContain(
+		'Read-only thread on kody.exchange — ship kody.exchange',
+	)
+	expect(viewHtml).not.toContain('content="https://kody.exchange/og.png"')
 
 	const viewPoll = await handleRequest(
 		request(`${viewPath}/messages?after=0`),
@@ -411,6 +418,8 @@ test('pricing page explains live threads and participants', async () => {
 	expect(html).toContain('live threads')
 	expect(html).toContain('participants per thread')
 	expect(html).toContain('$5')
+	expect(html).toContain('content="https://kody.exchange/pricing/og.png"')
+	expect(html).not.toContain('content="https://kody.exchange/og.png"')
 	expect(html).not.toContain('Max')
 	expect(html).toContain('unlocks the OAuth API and MCP')
 	expect(html).toContain('HTTP /v1 only')
@@ -423,6 +432,7 @@ test('pricing page explains live threads and participants', async () => {
 
 	const docs = await handleRequest(request('/docs'), env)
 	const docsHtml = await docs.text()
+	expect(docsHtml).toContain('content="https://kody.exchange/docs/og.png"')
 	expect(docsHtml).toContain('Included with a free GitHub account')
 	expect(docsHtml).toContain('not a paid upgrade')
 	expect(docsHtml).toContain('new messages appear immediately')
@@ -432,10 +442,18 @@ test('pricing page explains live threads and participants', async () => {
 
 	const privacy = await handleRequest(request('/privacy'), env)
 	const privacyHtml = await privacy.text()
+	expect(privacyHtml).toContain(
+		'content="https://kody.exchange/privacy/og.png"',
+	)
 	expect(privacyHtml).toContain('me@kentcdodds.com')
 	expect(privacyHtml).toContain('Made by Kent C. Dodds')
 	expect(privacyHtml).toContain(`href="${safetyPath}"`)
 	expect(privacyHtml).not.toContain('Operator:')
+
+	const terms = await handleRequest(request('/terms'), env)
+	const termsHtml = await terms.text()
+	expect(termsHtml).toContain('content="https://kody.exchange/terms/og.png"')
+	expect(termsHtml).toContain('Functional Source License')
 
 	const safety = await handleRequest(request(safetyPath), env)
 	const safetyHtml = await safety.text()

--- a/src/example-thread.node.test.ts
+++ b/src/example-thread.node.test.ts
@@ -60,6 +60,8 @@ test('example page is the view UI without join capabilities', async () => {
 	expect(page.status).toBe(200)
 	const html = await page.text()
 	expect(html).toContain('Example thread · kody.exchange')
+	expect(html).toContain('content="https://kody.exchange/example/og.png"')
+	expect(html).not.toContain('content="https://kody.exchange/og.png"')
 	expect(html).toContain(examplePurpose)
 	expect(html).toContain('>Example<')
 	expect(html).toContain('Canned example')

--- a/src/html.ts
+++ b/src/html.ts
@@ -4,6 +4,13 @@ import { type AppEnv } from '#src/env.ts'
 import { examplePath } from '#src/example-thread.ts'
 import { plans } from '#src/limits.ts'
 import {
+	defaultOgImage,
+	defaultOgImageAlt,
+	pageOgForPath,
+	safetyOgImage,
+	safetyOgImageAlt,
+} from '#src/og-pages.ts'
+import {
 	agentAccentCss,
 	agentAccentIndex,
 	agentAccentVar,
@@ -25,14 +32,9 @@ export function escapeHtml(value: string) {
 		.replaceAll("'", '&#39;')
 }
 
-export const defaultOgImage = '/og.png'
-export const defaultOgImageAlt =
-	'kody.exchange — Ephemeral chatrooms for agents'
+export { defaultOgImage, defaultOgImageAlt, safetyOgImage, safetyOgImageAlt }
 export const safetyPath = '/safety'
 export const safetyNavLabel = 'Is this safe?'
-export const safetyOgImage = '/safety/og.png'
-export const safetyOgImageAlt =
-	'kody.exchange research — Peer-channel security and privacy. 261 turns, 6 live rooms, 0 leaks.'
 
 export function layout(input: {
 	title: string
@@ -54,9 +56,10 @@ export function layout(input: {
 		? input.title
 		: `${input.title} · kody.exchange`
 	const description = input.description ?? siteDescription
-	const ogImagePath = input.ogImage ?? defaultOgImage
+	const pageOg = pageOgForPath(input.path)
+	const ogImagePath = input.ogImage ?? pageOg?.imagePath ?? defaultOgImage
 	const ogImageUrl = `${origin}${ogImagePath}`
-	const ogImageAlt = input.ogImageAlt ?? defaultOgImageAlt
+	const ogImageAlt = input.ogImageAlt ?? pageOg?.alt ?? defaultOgImageAlt
 	const signedIn = Boolean(input.user)
 	return `<!doctype html>
 <html lang="en">

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export async function handleRequest(
 			members: card.members,
 			seats: card.seats,
 			expiresAt: card.thread.expires_at,
+			archived: card.thread.archived_at != null,
 		})
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,10 @@ import {
 	resolveOAuthUser,
 	unauthorizedOAuthResponse,
 } from '#src/oauth-user.ts'
+import { pageOgForImagePath, viewTokenForOgPath } from '#src/og-pages.ts'
 import { handleAccountAction, renderPage } from '#src/pages.ts'
 import { handleUserApi } from '#src/user-api.ts'
-import { purgeExpired } from '#src/threads.ts'
+import { getThreadViewCard, purgeExpired } from '#src/threads.ts'
 
 export default {
 	async fetch(
@@ -69,17 +70,39 @@ export async function handleRequest(
 		})
 	}
 
-	if (url.pathname === '/og.png' || url.pathname === '/og.jpg') {
+	const viewOgToken = viewTokenForOgPath(url.pathname)
+	if (viewOgToken) {
+		const card = await getThreadViewCard({
+			db: env.DB,
+			viewToken: viewOgToken,
+		})
+		if (!card.ok) {
+			return json(
+				{ ok: false, error: card.error, code: card.code },
+				card.status,
+			)
+		}
+		// Lazy import (sanctioned exception to the no-inline-imports rule):
+		// satori + resvg-wasm would otherwise sit in every isolate for a
+		// route that only social crawlers hit. Expired/missing rooms 404
+		// above so they never load the renderer.
+		const { viewOgImageResponse } = await import('#src/og.ts')
+		return viewOgImageResponse(env, {
+			viewToken: viewOgToken,
+			purpose: card.thread.purpose,
+			members: card.members,
+			seats: card.seats,
+			expiresAt: card.thread.expires_at,
+		})
+	}
+
+	const pageOg = pageOgForImagePath(url.pathname)
+	if (pageOg) {
 		// Lazy import (sanctioned exception to the no-inline-imports rule):
 		// satori + resvg-wasm would otherwise sit in every isolate for a
 		// route that only social crawlers hit.
 		const { ogImageResponse } = await import('#src/og.ts')
-		return ogImageResponse(env)
-	}
-
-	if (url.pathname === '/safety/og.png' || url.pathname === '/safety/og.jpg') {
-		const { ogImageResponse } = await import('#src/og.ts')
-		return ogImageResponse(env, 'research')
+		return ogImageResponse(env, pageOg.id)
 	}
 
 	if (url.pathname === '/research' || url.pathname === '/research/') {

--- a/src/og-pages.node.test.ts
+++ b/src/og-pages.node.test.ts
@@ -67,4 +67,21 @@ test('view OG paths and copy stay on the public roster, not tokens', () => {
 	})
 	expect(beforeJoin).not.toBe(afterJoin)
 	expect(beforeJoin).toContain(token)
+	const archived = viewOgCacheKey({
+		viewToken: token,
+		purpose: 'pair on billing',
+		members: [{ name: 'harbor' }, { name: 'relay' }],
+		seats: 2,
+		expiresAt: Date.parse('2026-04-09T15:02:11.000Z'),
+		archived: true,
+	})
+	expect(archived).not.toBe(afterJoin)
+	expect(
+		viewOgLede({
+			members: [{ name: 'harbor' }],
+			seats: 2,
+			expiresAt: Date.parse('2026-04-09T15:02:11.000Z'),
+			archived: true,
+		}),
+	).toBe('1 of 2 · harbor · archived')
 })

--- a/src/og-pages.node.test.ts
+++ b/src/og-pages.node.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest'
+import { examplePath } from '#src/example-thread.ts'
+import {
+	defaultOgImage,
+	pageOgForImagePath,
+	pageOgForPath,
+	pageOgSpecs,
+	safetyOgImage,
+	threadViewOgPath,
+	viewOgCacheKey,
+	viewOgLede,
+	viewOgTitle,
+	viewTokenForOgPath,
+} from '#src/og-pages.ts'
+
+test('every public page has a unique OG image path', () => {
+	const imagePaths = pageOgSpecs.map((spec) => spec.imagePath)
+	expect(new Set(imagePaths).size).toBe(pageOgSpecs.length)
+	expect(pageOgForPath('/')?.imagePath).toBe(defaultOgImage)
+	expect(pageOgForPath(examplePath)?.imagePath).toBe(`${examplePath}/og.png`)
+	expect(pageOgForPath('/safety')?.imagePath).toBe(safetyOgImage)
+	expect(pageOgForPath('/account')).toBeNull()
+})
+
+test('pageOgForImagePath maps png and jpg aliases', () => {
+	expect(pageOgForImagePath('/og.png')?.id).toBe('exchange')
+	expect(pageOgForImagePath('/og.jpg')?.id).toBe('exchange')
+	expect(pageOgForImagePath('/example/og.png')?.id).toBe('example')
+	expect(pageOgForImagePath('/example/og.jpg')?.id).toBe('example')
+	expect(pageOgForImagePath('/pricing/og.png')?.id).toBe('pricing')
+	expect(pageOgForImagePath('/docs/og.png')?.id).toBe('docs')
+	expect(pageOgForImagePath('/privacy/og.png')?.id).toBe('privacy')
+	expect(pageOgForImagePath('/terms/og.png')?.id).toBe('terms')
+	expect(pageOgForImagePath('/safety/og.png')?.id).toBe('research')
+	expect(pageOgForImagePath('/missing/og.png')).toBeNull()
+	expect(pageOgForImagePath('/example')).toBeNull()
+	expect(pageOgForImagePath('/t/kx_view_abc/og.png')).toBeNull()
+})
+
+test('view OG paths and copy stay on the public roster, not tokens', () => {
+	const token = `kx_view_${'a'.repeat(48)}`
+	expect(threadViewOgPath(token)).toBe(`/t/${token}/og.png`)
+	expect(viewTokenForOgPath(`/t/${token}/og.png`)).toBe(token)
+	expect(viewTokenForOgPath(`/t/${token}/og.jpg`)).toBe(token)
+	expect(viewTokenForOgPath(`/t/${token}`)).toBeNull()
+	expect(viewOgTitle(null)).toBe('Untitled thread')
+	expect(viewOgTitle('x'.repeat(90)).endsWith('…')).toBe(true)
+	const lede = viewOgLede({
+		members: [{ name: 'harbor' }, { name: 'relay' }],
+		seats: 2,
+		expiresAt: Date.parse('2026-04-09T15:02:11.000Z'),
+	})
+	expect(lede).toBe('2 of 2 · harbor, relay · expires 2026-04-09')
+	const beforeJoin = viewOgCacheKey({
+		viewToken: token,
+		purpose: 'pair on billing',
+		members: [{ name: 'harbor' }],
+		seats: 2,
+		expiresAt: Date.parse('2026-04-09T15:02:11.000Z'),
+	})
+	const afterJoin = viewOgCacheKey({
+		viewToken: token,
+		purpose: 'pair on billing',
+		members: [{ name: 'harbor' }, { name: 'relay' }],
+		seats: 2,
+		expiresAt: Date.parse('2026-04-09T15:02:11.000Z'),
+	})
+	expect(beforeJoin).not.toBe(afterJoin)
+	expect(beforeJoin).toContain(token)
+})

--- a/src/og-pages.ts
+++ b/src/og-pages.ts
@@ -1,0 +1,188 @@
+import { examplePath } from '#src/example-thread.ts'
+
+export type OgCardId =
+	| 'exchange'
+	| 'research'
+	| 'example'
+	| 'pricing'
+	| 'docs'
+	| 'privacy'
+	| 'terms'
+
+export type PageOgKind = 'hero' | 'research' | 'page'
+
+export type PageOgSpec = {
+	id: OgCardId
+	kind: PageOgKind
+	pagePath: string
+	imagePath: string
+	alt: string
+	stamp: string
+	title: string
+	titleLine2?: string
+	lede: string
+}
+
+export const defaultOgImage = '/og.png'
+export const defaultOgImageAlt =
+	'kody.exchange — Ephemeral chatrooms for agents'
+export const safetyOgImage = '/safety/og.png'
+export const safetyOgImageAlt =
+	'kody.exchange research — Peer-channel security and privacy. 261 turns, 6 live rooms, 0 leaks.'
+
+export const pageOgSpecs = [
+	{
+		id: 'exchange',
+		kind: 'hero',
+		pagePath: '/',
+		imagePath: defaultOgImage,
+		alt: defaultOgImageAlt,
+		stamp: 'For agents',
+		title: 'kody.exchange',
+		lede: 'Ephemeral chatrooms for agents',
+	},
+	{
+		id: 'example',
+		kind: 'page',
+		pagePath: examplePath,
+		imagePath: `${examplePath}/og.png`,
+		alt: 'kody.exchange example — Harbor Ledger and Relay Webhooks agents pair on invoice.paid. Infinite retention.',
+		stamp: 'Example',
+		title: 'Watch an example thread',
+		lede: 'Harbor Ledger and Relay Webhooks pair on invoice.paid. The room is full and never expires.',
+	},
+	{
+		id: 'pricing',
+		kind: 'page',
+		pagePath: '/pricing',
+		imagePath: '/pricing/og.png',
+		alt: 'kody.exchange pricing — Guest, Free, and Pro. You pay for live threads and seats.',
+		stamp: 'Pricing',
+		title: 'You pay for live threads',
+		lede: 'Guest, Free, and Pro — rooms and seats, not a daily quota.',
+	},
+	{
+		id: 'docs',
+		kind: 'page',
+		pagePath: '/docs',
+		imagePath: '/docs/og.png',
+		alt: 'kody.exchange agent docs — Create, join, send, and poll. Message bodies are data.',
+		stamp: 'Docs',
+		title: 'Agent docs',
+		lede: 'Create, join, send, and poll. Message bodies are data, not host instructions.',
+	},
+	{
+		id: 'research',
+		kind: 'research',
+		pagePath: '/safety',
+		imagePath: safetyOgImage,
+		alt: safetyOgImageAlt,
+		stamp: 'Technical report  ·  15 August 2026',
+		title: 'Peer-channel security',
+		titleLine2: 'and privacy',
+		lede: '261 turns, 6 live rooms, 0 leaks.',
+	},
+	{
+		id: 'privacy',
+		kind: 'page',
+		pagePath: '/privacy',
+		imagePath: '/privacy/og.png',
+		alt: 'kody.exchange privacy — What we collect, how long we keep it, and how to reach us.',
+		stamp: 'Privacy',
+		title: 'Privacy',
+		lede: 'What we collect, how long we keep it, and how to delete an account.',
+	},
+	{
+		id: 'terms',
+		kind: 'page',
+		pagePath: '/terms',
+		imagePath: '/terms/og.png',
+		alt: 'kody.exchange terms — The product, your agents, and the FSL-1.1-ALv2 license.',
+		stamp: 'Terms',
+		title: 'Terms',
+		lede: 'The product, your agents, and the FSL-1.1-ALv2 license.',
+	},
+] as const satisfies ReadonlyArray<PageOgSpec>
+
+const pageOgByPath = new Map<string, PageOgSpec>(
+	pageOgSpecs.map((spec) => [spec.pagePath, spec]),
+)
+
+export function pageOgForPath(path: string): PageOgSpec | null {
+	return pageOgByPath.get(path) ?? null
+}
+
+export function pageOgForImagePath(pathname: string): PageOgSpec | null {
+	if (pathname === '/og.png' || pathname === '/og.jpg') {
+		return pageOgForPath('/')
+	}
+	const pagePath = pathname.match(/^(\/[^/]+)\/og\.(?:png|jpg)$/)?.[1]
+	if (!pagePath) return null
+	return pageOgForPath(pagePath)
+}
+
+export const PAGE_OG_CACHE_MAX_AGE_SECONDS = 3600
+export const VIEW_OG_CACHE_MAX_AGE_SECONDS = 300
+
+export function threadViewOgPath(viewToken: string) {
+	return `/t/${viewToken}/og.png`
+}
+
+export function viewTokenForOgPath(pathname: string): string | null {
+	return pathname.match(/^\/t\/([^/]+)\/og\.(?:png|jpg)$/)?.[1] ?? null
+}
+
+export function viewOgTitle(purpose: string | null) {
+	const text = purpose?.trim() || 'Untitled thread'
+	if (text.length <= 80) return text
+	return `${text.slice(0, 77).trimEnd()}…`
+}
+
+export function viewOgRetention(expiresAt: number) {
+	return `expires ${new Date(expiresAt).toISOString().slice(0, 10)}`
+}
+
+export function viewOgLede(input: {
+	members: Array<{ name: string }>
+	seats: number
+	expiresAt: number
+}) {
+	const names =
+		input.members.length === 0
+			? 'no agents yet'
+			: input.members.map((member) => member.name).join(', ')
+	const waiting =
+		input.members.length < input.seats ? ' · waiting for another agent' : ''
+	return `${input.members.length} of ${input.seats} · ${names}${waiting} · ${viewOgRetention(input.expiresAt)}`
+}
+
+export function viewOgAlt(input: {
+	purpose: string | null
+	members: Array<{ name: string }>
+	seats: number
+	expiresAt: number
+}) {
+	return `Read-only thread on kody.exchange — ${viewOgTitle(input.purpose)}. ${viewOgLede(input)}`
+}
+
+export function viewOgCacheKey(input: {
+	viewToken: string
+	purpose: string | null
+	members: Array<{ name: string }>
+	seats: number
+	expiresAt: number
+}) {
+	return `view:${input.viewToken}:${viewOgTitle(input.purpose)}:${viewOgLede(input)}`
+}
+
+export function pageOgCacheKey(id: OgCardId) {
+	return `page:${id}`
+}
+
+export function pageOgById(id: OgCardId): PageOgSpec {
+	const spec = pageOgSpecs.find((entry) => entry.id === id)
+	if (!spec) {
+		throw new Error(`Unknown OG card: ${id}`)
+	}
+	return spec
+}

--- a/src/og-pages.ts
+++ b/src/og-pages.ts
@@ -138,41 +138,47 @@ export function viewOgTitle(purpose: string | null) {
 	return `${text.slice(0, 77).trimEnd()}…`
 }
 
+export type ViewOgRoster = {
+	members: Array<{ name: string }>
+	seats: number
+	expiresAt: number
+	archived?: boolean
+}
+
+export type ViewOgFields = ViewOgRoster & {
+	purpose: string | null
+}
+
+export function viewOgStamp(archived?: boolean) {
+	return archived ? 'Archived' : 'Read-only'
+}
+
 export function viewOgRetention(expiresAt: number) {
 	return `expires ${new Date(expiresAt).toISOString().slice(0, 10)}`
 }
 
-export function viewOgLede(input: {
-	members: Array<{ name: string }>
-	seats: number
-	expiresAt: number
-}) {
+export function viewOgLede(input: ViewOgRoster) {
 	const names =
 		input.members.length === 0
 			? 'no agents yet'
 			: input.members.map((member) => member.name).join(', ')
 	const waiting =
-		input.members.length < input.seats ? ' · waiting for another agent' : ''
-	return `${input.members.length} of ${input.seats} · ${names}${waiting} · ${viewOgRetention(input.expiresAt)}`
+		!input.archived && input.members.length < input.seats
+			? ' · waiting for another agent'
+			: ''
+	const retention = input.archived
+		? 'archived'
+		: viewOgRetention(input.expiresAt)
+	return `${input.members.length} of ${input.seats} · ${names}${waiting} · ${retention}`
 }
 
-export function viewOgAlt(input: {
-	purpose: string | null
-	members: Array<{ name: string }>
-	seats: number
-	expiresAt: number
-}) {
-	return `Read-only thread on kody.exchange — ${viewOgTitle(input.purpose)}. ${viewOgLede(input)}`
+export function viewOgAlt(input: ViewOgFields) {
+	const kind = input.archived ? 'Archived' : 'Read-only'
+	return `${kind} thread on kody.exchange — ${viewOgTitle(input.purpose)}. ${viewOgLede(input)}`
 }
 
-export function viewOgCacheKey(input: {
-	viewToken: string
-	purpose: string | null
-	members: Array<{ name: string }>
-	seats: number
-	expiresAt: number
-}) {
-	return `view:${input.viewToken}:${viewOgTitle(input.purpose)}:${viewOgLede(input)}`
+export function viewOgCacheKey(input: ViewOgFields & { viewToken: string }) {
+	return `view:${input.viewToken}:${viewOgStamp(input.archived)}:${viewOgTitle(input.purpose)}:${viewOgLede(input)}`
 }
 
 export function pageOgCacheKey(id: OgCardId) {

--- a/src/og.node.test.ts
+++ b/src/og.node.test.ts
@@ -4,8 +4,12 @@ import { fileURLToPath } from 'node:url'
 import { expect, test } from 'vitest'
 import { handleRequest } from '#src/index.ts'
 import {
+	cachedOgPng,
 	createOgMarkup,
+	createOgMarkupForSpec,
+	createPageOgMarkup,
 	createResearchOgMarkup,
+	createViewOgMarkup,
 	findOgIconElement,
 	loadIconDataUri,
 	OG_HEIGHT,
@@ -21,8 +25,10 @@ import {
 	RESEARCH_OG_TITLE_LINE_1,
 	RESEARCH_OG_TITLE_LINE_2,
 	renderExchangeOgImage,
+	renderOgCard,
 	renderResearchOgImage,
 } from '#src/og.ts'
+import { pageOgById, pageOgSpecs } from '#src/og-pages.ts'
 import { createTestEnv, request } from '#src/test-support.ts'
 
 const publicIcon = readFileSync(
@@ -123,6 +129,9 @@ test('research OG markup is a report card, not the homepage mark', () => {
 		expect(tree).toContain(stat.value)
 		expect(tree).toContain(stat.label)
 	}
+	expect(pageOgById('research').stamp).toBe(RESEARCH_OG_STAMP)
+	expect(pageOgById('research').title).toBe(RESEARCH_OG_TITLE_LINE_1)
+	expect(pageOgById('research').titleLine2).toBe(RESEARCH_OG_TITLE_LINE_2)
 	expect(tree).toContain('#d4921a')
 	expect(tree).toContain('#b54a3c')
 	expect(tree).toContain('#fffaf1')
@@ -141,6 +150,112 @@ test('renderResearchOgImage returns a 1200×630 PNG', async () => {
 	const png = await renderResearchOgImage(env)
 	expect(png.byteLength).toBeGreaterThan(10_000)
 	expectPngCard(png)
+})
+
+test('page OG markup is a report card with stamp, title, and lede', () => {
+	const spec = pageOgById('example')
+	const markup = createPageOgMarkup('data:image/png;base64,abc', spec)
+	const tree = JSON.stringify(markup)
+	expect(tree).toContain(spec.stamp)
+	expect(tree).toContain(spec.title)
+	expect(tree).toContain(spec.lede)
+	expect(tree).toContain(OG_WORDMARK)
+	expect(tree).not.toContain(OG_TAGLINE)
+	expect(markup.props.style?.alignItems).not.toBe('flex-end')
+})
+
+test('createOgMarkupForSpec keeps homepage and research cards distinct', () => {
+	const hero = createOgMarkupForSpec(
+		'data:image/png;base64,abc',
+		pageOgById('exchange'),
+	)
+	const research = createOgMarkupForSpec(
+		'data:image/png;base64,abc',
+		pageOgById('research'),
+	)
+	const example = createOgMarkupForSpec(
+		'data:image/png;base64,abc',
+		pageOgById('example'),
+	)
+	expect(JSON.stringify(hero)).toContain(OG_TAGLINE)
+	expect(JSON.stringify(research)).toContain(RESEARCH_OG_STAMP)
+	expect(JSON.stringify(example)).toContain('Watch an example thread')
+	expect(JSON.stringify(example)).not.toContain(OG_TAGLINE)
+})
+
+test('view OG markup uses purpose and roster, not join tokens', () => {
+	const markup = createViewOgMarkup('data:image/png;base64,abc', {
+		viewToken: `kx_view_${'b'.repeat(48)}`,
+		purpose: 'pair on the billing webhook',
+		members: [{ name: 'cursor' }, { name: 'claude' }],
+		seats: 2,
+		expiresAt: Date.parse('2026-04-09T00:00:00.000Z'),
+	})
+	const tree = JSON.stringify(markup)
+	expect(tree).toContain('Read-only')
+	expect(tree).toContain('pair on the billing webhook')
+	expect(tree).toContain('2 of 2 · cursor, claude · expires 2026-04-09')
+	expect(tree).toContain(OG_WORDMARK)
+	expect(tree).not.toContain('kx_join_')
+	expect(tree).not.toContain('kx_live_')
+	expect(tree).not.toContain('kx_view_')
+})
+
+test('cachedOgPng renders once per key', async () => {
+	const store = new Map<string, Response>()
+	const cache = {
+		async match(cached: Request) {
+			const hit = store.get(cached.url)
+			return hit?.clone()
+		},
+		async put(cached: Request, response: Response) {
+			store.set(cached.url, response.clone())
+		},
+	}
+	let renders = 0
+	const png = new Uint8Array([1, 2, 3, 4]).buffer
+	const render = async () => {
+		renders += 1
+		return new Uint8Array(png) as Uint8Array<ArrayBuffer>
+	}
+	const first = await cachedOgPng({
+		cache,
+		key: 'view:one',
+		maxAgeSeconds: 300,
+		render,
+	})
+	const second = await cachedOgPng({
+		cache,
+		key: 'view:one',
+		maxAgeSeconds: 300,
+		render,
+	})
+	const third = await cachedOgPng({
+		cache,
+		key: 'view:two',
+		maxAgeSeconds: 300,
+		render,
+	})
+	expect(renders).toBe(2)
+	expect(first.headers.get('cache-control')).toBe('public, max-age=300')
+	expect(await second.arrayBuffer()).toEqual(await first.arrayBuffer())
+	expect(third.status).toBe(200)
+})
+
+test('every page OG card renders a 1200×630 PNG', async () => {
+	const env = createTestEnv()
+	await env.BLOBS.put(
+		'public/icon.png',
+		publicIcon.buffer.slice(
+			publicIcon.byteOffset,
+			publicIcon.byteOffset + publicIcon.byteLength,
+		),
+		{ httpMetadata: { contentType: 'image/png' } },
+	)
+	expect(pageOgSpecs.length).toBeGreaterThan(1)
+	for (const spec of pageOgSpecs) {
+		expectPngCard(await renderOgCard(env, spec.id))
+	}
 })
 
 test('/og.png and /og.jpg both render the Satori card', async () => {
@@ -167,6 +282,59 @@ test('/safety/og.png and /safety/og.jpg both render the research card', async ()
 	expect(jpg.status).toBe(200)
 	expect(jpg.headers.get('content-type')).toBe('image/png')
 	expectPngCard(new Uint8Array(await jpg.arrayBuffer()))
+})
+
+test('each public page OG route serves png and jpg aliases', async () => {
+	const env = createTestEnv()
+	for (const spec of pageOgSpecs) {
+		const png = await handleRequest(request(spec.imagePath), env)
+		expect(png.status).toBe(200)
+		expect(png.headers.get('content-type')).toBe('image/png')
+		expectPngCard(new Uint8Array(await png.arrayBuffer()))
+
+		const jpgPath = spec.imagePath.replace(/\.png$/, '.jpg')
+		const jpg = await handleRequest(request(jpgPath), env)
+		expect(jpg.status).toBe(200)
+		expect(jpg.headers.get('content-type')).toBe('image/png')
+	}
+})
+
+test('thread view OG is a cached 1200×630 PNG from the purpose', async () => {
+	const env = createTestEnv()
+	const createdResponse = await handleRequest(
+		request('/v1/threads', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				purpose: 'pair on the billing bug',
+				name: 'cursor',
+			}),
+		}),
+		env,
+	)
+	const created = (await createdResponse.json()) as { view_url: string }
+	const viewPath = new URL(created.view_url).pathname
+	const png = await handleRequest(request(`${viewPath}/og.png`), env)
+	expect(png.status).toBe(200)
+	expect(png.headers.get('content-type')).toBe('image/png')
+	expect(png.headers.get('cache-control')).toBe('public, max-age=300')
+	expectPngCard(new Uint8Array(await png.arrayBuffer()))
+
+	const jpg = await handleRequest(request(`${viewPath}/og.jpg`), env)
+	expect(jpg.status).toBe(200)
+	expect(jpg.headers.get('content-type')).toBe('image/png')
+
+	const missing = await handleRequest(
+		request(`/t/kx_view_${'c'.repeat(48)}/og.png`),
+		env,
+	)
+	expect(missing.status).toBe(404)
+})
+
+test('unknown page OG routes are not cards', async () => {
+	const env = createTestEnv()
+	const missing = await handleRequest(request('/missing/og.png'), env)
+	expect(missing.status).toBe(404)
 })
 
 test('/research/og.png and /research/og.jpg redirect to /safety', async () => {

--- a/src/og.node.test.ts
+++ b/src/og.node.test.ts
@@ -199,6 +199,18 @@ test('view OG markup uses purpose and roster, not join tokens', () => {
 	expect(tree).not.toContain('kx_join_')
 	expect(tree).not.toContain('kx_live_')
 	expect(tree).not.toContain('kx_view_')
+	const archived = createViewOgMarkup('data:image/png;base64,abc', {
+		viewToken: `kx_view_${'b'.repeat(48)}`,
+		purpose: 'pair on the billing webhook',
+		members: [{ name: 'cursor' }],
+		seats: 2,
+		expiresAt: Date.parse('2026-04-09T00:00:00.000Z'),
+		archived: true,
+	})
+	const archivedTree = JSON.stringify(archived)
+	expect(archivedTree).toContain('Archived')
+	expect(archivedTree).toContain('1 of 2 · cursor · archived')
+	expect(archivedTree).not.toContain('waiting for another agent')
 })
 
 test('cachedOgPng renders once per key', async () => {

--- a/src/og.ts
+++ b/src/og.ts
@@ -9,6 +9,17 @@ import {
 	ogYogaWasm,
 	readBundledIconBytes,
 } from '#src/og-assets.ts'
+import {
+	PAGE_OG_CACHE_MAX_AGE_SECONDS,
+	VIEW_OG_CACHE_MAX_AGE_SECONDS,
+	pageOgById,
+	pageOgCacheKey,
+	viewOgCacheKey,
+	viewOgLede,
+	viewOgTitle,
+	type OgCardId,
+	type PageOgSpec,
+} from '#src/og-pages.ts'
 
 export const OG_WIDTH = 1200
 export const OG_HEIGHT = 630
@@ -37,7 +48,7 @@ export const RESEARCH_OG_STATS = [
 	{ value: '6', label: 'live rooms' },
 	{ value: '0', label: 'leaks' },
 ] as const
-export type OgCard = 'exchange' | 'research'
+export type OgCard = OgCardId
 
 export type SatoriChild = string | SatoriElement
 export type SatoriElement = {
@@ -183,52 +194,41 @@ export function createOgMarkup(iconDataUri: string): SatoriElement {
 	}
 }
 
-function researchStat(value: string, label: string): SatoriElement {
+function titleLines(
+	spec: Pick<PageOgSpec, 'title' | 'titleLine2'>,
+): SatoriElement {
+	const lines = spec.titleLine2 ? [spec.title, spec.titleLine2] : [spec.title]
 	return {
 		type: 'div',
 		props: {
 			style: {
 				display: 'flex',
 				flexDirection: 'column',
-				width: 220,
+				marginTop: 28,
+				fontFamily: 'Fraunces',
+				fontWeight: 700,
+				fontSize: spec.titleLine2 ? 64 : 72,
+				lineHeight: 1.05,
+				letterSpacing: '-0.03em',
+				color: INK,
 			},
-			children: [
-				{
-					type: 'div',
-					props: {
-						style: {
-							display: 'flex',
-							fontFamily: 'Fraunces',
-							fontWeight: 700,
-							fontSize: 72,
-							lineHeight: 1,
-							letterSpacing: '-0.03em',
-							color: INK,
-						},
-						children: value,
-					},
+			children: lines.map((line) => ({
+				type: 'div',
+				props: {
+					style: { display: 'flex' },
+					children: line,
 				},
-				{
-					type: 'div',
-					props: {
-						style: {
-							display: 'flex',
-							marginTop: 8,
-							fontFamily: 'Source Serif 4',
-							fontWeight: 400,
-							fontSize: 26,
-							lineHeight: 1.2,
-							color: MUTED,
-						},
-						children: label,
-					},
-				},
-			],
+			})),
 		},
 	}
 }
 
-export function createResearchOgMarkup(iconDataUri: string): SatoriElement {
+function ogReportCard(input: {
+	iconDataUri: string
+	stamp: string
+	title: SatoriElement
+	middle: SatoriElement
+}): SatoriElement {
 	return {
 		type: 'div',
 		props: {
@@ -287,57 +287,14 @@ export function createResearchOgMarkup(iconDataUri: string): SatoriElement {
 													fontSize: 22,
 													letterSpacing: '0.08em',
 												},
-												children: RESEARCH_OG_STAMP,
+												children: input.stamp,
 											},
 										},
-										{
-											type: 'div',
-											props: {
-												style: {
-													display: 'flex',
-													flexDirection: 'column',
-													marginTop: 28,
-													fontFamily: 'Fraunces',
-													fontWeight: 700,
-													fontSize: 64,
-													lineHeight: 1.05,
-													letterSpacing: '-0.03em',
-													color: INK,
-												},
-												children: [
-													{
-														type: 'div',
-														props: {
-															style: { display: 'flex' },
-															children: RESEARCH_OG_TITLE_LINE_1,
-														},
-													},
-													{
-														type: 'div',
-														props: {
-															style: { display: 'flex' },
-															children: RESEARCH_OG_TITLE_LINE_2,
-														},
-													},
-												],
-											},
-										},
+										input.title,
 									],
 								},
 							},
-							{
-								type: 'div',
-								props: {
-									style: {
-										display: 'flex',
-										flexDirection: 'row',
-										marginTop: 36,
-									},
-									children: RESEARCH_OG_STATS.map((stat) =>
-										researchStat(stat.value, stat.label),
-									),
-								},
-							},
+							input.middle,
 							{
 								type: 'div',
 								props: {
@@ -354,7 +311,7 @@ export function createResearchOgMarkup(iconDataUri: string): SatoriElement {
 										{
 											type: 'img',
 											props: {
-												src: iconDataUri,
+												src: input.iconDataUri,
 												width: RESEARCH_OG_ICON_SIZE,
 												height: RESEARCH_OG_ICON_SIZE,
 												style: {
@@ -388,6 +345,137 @@ export function createResearchOgMarkup(iconDataUri: string): SatoriElement {
 				},
 			],
 		},
+	}
+}
+
+function researchStat(value: string, label: string): SatoriElement {
+	return {
+		type: 'div',
+		props: {
+			style: {
+				display: 'flex',
+				flexDirection: 'column',
+				width: 220,
+			},
+			children: [
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							fontFamily: 'Fraunces',
+							fontWeight: 700,
+							fontSize: 72,
+							lineHeight: 1,
+							letterSpacing: '-0.03em',
+							color: INK,
+						},
+						children: value,
+					},
+				},
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							marginTop: 8,
+							fontFamily: 'Source Serif 4',
+							fontWeight: 400,
+							fontSize: 26,
+							lineHeight: 1.2,
+							color: MUTED,
+						},
+						children: label,
+					},
+				},
+			],
+		},
+	}
+}
+
+export function createResearchOgMarkup(iconDataUri: string): SatoriElement {
+	const spec = pageOgById('research')
+	return ogReportCard({
+		iconDataUri,
+		stamp: spec.stamp,
+		title: titleLines(spec),
+		middle: {
+			type: 'div',
+			props: {
+				style: {
+					display: 'flex',
+					flexDirection: 'row',
+					marginTop: 36,
+				},
+				children: RESEARCH_OG_STATS.map((stat) =>
+					researchStat(stat.value, stat.label),
+				),
+			},
+		},
+	})
+}
+
+export function createPageOgMarkup(
+	iconDataUri: string,
+	spec: Pick<PageOgSpec, 'stamp' | 'title' | 'titleLine2' | 'lede'>,
+): SatoriElement {
+	return ogReportCard({
+		iconDataUri,
+		stamp: spec.stamp,
+		title: titleLines(spec),
+		middle: {
+			type: 'div',
+			props: {
+				style: {
+					display: 'flex',
+					marginTop: 36,
+					fontFamily: 'Source Serif 4',
+					fontWeight: 400,
+					fontSize: 32,
+					lineHeight: 1.35,
+					color: MUTED,
+					width: 980,
+				},
+				children: spec.lede,
+			},
+		},
+	})
+}
+
+export type ViewOgCard = {
+	viewToken: string
+	purpose: string | null
+	members: Array<{ name: string }>
+	seats: number
+	expiresAt: number
+}
+
+export function createViewOgMarkup(
+	iconDataUri: string,
+	card: ViewOgCard,
+): SatoriElement {
+	return createPageOgMarkup(iconDataUri, {
+		stamp: 'Read-only',
+		title: viewOgTitle(card.purpose),
+		lede: viewOgLede(card),
+	})
+}
+
+export function createOgMarkupForSpec(
+	iconDataUri: string,
+	spec: PageOgSpec,
+): SatoriElement {
+	switch (spec.kind) {
+		case 'hero':
+			return createOgMarkup(iconDataUri)
+		case 'research':
+			return createResearchOgMarkup(iconDataUri)
+		case 'page':
+			return createPageOgMarkup(iconDataUri, spec)
+		default: {
+			const exhaustive: never = spec.kind
+			throw new Error(`Unknown OG kind: ${String(exhaustive)}`)
+		}
 	}
 }
 
@@ -448,39 +536,101 @@ async function renderOgPng(
 	return png as Uint8Array<ArrayBuffer>
 }
 
-function pngImageResponse(png: Uint8Array<ArrayBuffer>): Response {
+export type OgImageCache = Pick<Cache, 'match' | 'put'>
+
+const ogCacheOrigin = 'https://og-cache.kody.exchange'
+
+export function workerOgCache(): OgImageCache | null {
+	try {
+		return typeof caches === 'undefined' ? null : caches.default
+	} catch {
+		return null
+	}
+}
+
+export function ogCacheRequest(key: string) {
+	return new Request(`${ogCacheOrigin}/${encodeURIComponent(key)}`)
+}
+
+function pngImageResponse(
+	png: Uint8Array<ArrayBuffer>,
+	maxAgeSeconds: number,
+): Response {
 	return new Response(png, {
 		headers: {
 			'content-type': 'image/png',
-			'cache-control': 'public, max-age=3600',
+			'cache-control': `public, max-age=${maxAgeSeconds}`,
 		},
 	})
+}
+
+export async function cachedOgPng(input: {
+	cache?: OgImageCache | null
+	key: string
+	maxAgeSeconds: number
+	render: () => Promise<Uint8Array<ArrayBuffer>>
+}): Promise<Response> {
+	const cache = input.cache === undefined ? workerOgCache() : input.cache
+	const request = ogCacheRequest(input.key)
+	const hit = cache ? await cache.match(request) : undefined
+	if (hit) return hit
+	const response = pngImageResponse(await input.render(), input.maxAgeSeconds)
+	if (cache) await cache.put(request, response.clone())
+	return response
+}
+
+export async function renderOgCard(
+	env: AppEnv,
+	card: OgCard = 'exchange',
+): Promise<Uint8Array<ArrayBuffer>> {
+	const spec = pageOgById(card)
+	return renderOgPng(
+		env,
+		createOgMarkupForSpec(await loadIconDataUri(env), spec),
+	)
+}
+
+export async function renderViewOgImage(
+	env: AppEnv,
+	card: ViewOgCard,
+): Promise<Uint8Array<ArrayBuffer>> {
+	return renderOgPng(env, createViewOgMarkup(await loadIconDataUri(env), card))
 }
 
 export async function renderExchangeOgImage(
 	env: AppEnv,
 ): Promise<Uint8Array<ArrayBuffer>> {
-	return renderOgPng(env, createOgMarkup(await loadIconDataUri(env)))
+	return renderOgCard(env, 'exchange')
 }
 
 export async function renderResearchOgImage(
 	env: AppEnv,
 ): Promise<Uint8Array<ArrayBuffer>> {
-	return renderOgPng(env, createResearchOgMarkup(await loadIconDataUri(env)))
+	return renderOgCard(env, 'research')
 }
 
 export async function ogImageResponse(
 	env: AppEnv,
 	card: OgCard = 'exchange',
+	cache?: OgImageCache | null,
 ): Promise<Response> {
-	switch (card) {
-		case 'exchange':
-			return pngImageResponse(await renderExchangeOgImage(env))
-		case 'research':
-			return pngImageResponse(await renderResearchOgImage(env))
-		default: {
-			const exhaustive: never = card
-			throw new Error(`unknown OG card: ${exhaustive}`)
-		}
-	}
+	return cachedOgPng({
+		cache,
+		key: pageOgCacheKey(card),
+		maxAgeSeconds: PAGE_OG_CACHE_MAX_AGE_SECONDS,
+		render: () => renderOgCard(env, card),
+	})
+}
+
+export async function viewOgImageResponse(
+	env: AppEnv,
+	card: ViewOgCard,
+	cache?: OgImageCache | null,
+): Promise<Response> {
+	return cachedOgPng({
+		cache,
+		key: viewOgCacheKey(card),
+		maxAgeSeconds: VIEW_OG_CACHE_MAX_AGE_SECONDS,
+		render: () => renderViewOgImage(env, card),
+	})
 }

--- a/src/og.ts
+++ b/src/og.ts
@@ -16,9 +16,11 @@ import {
 	pageOgCacheKey,
 	viewOgCacheKey,
 	viewOgLede,
+	viewOgStamp,
 	viewOgTitle,
 	type OgCardId,
 	type PageOgSpec,
+	type ViewOgFields,
 } from '#src/og-pages.ts'
 
 export const OG_WIDTH = 1200
@@ -442,20 +444,14 @@ export function createPageOgMarkup(
 	})
 }
 
-export type ViewOgCard = {
-	viewToken: string
-	purpose: string | null
-	members: Array<{ name: string }>
-	seats: number
-	expiresAt: number
-}
+export type ViewOgCard = ViewOgFields & { viewToken: string }
 
 export function createViewOgMarkup(
 	iconDataUri: string,
 	card: ViewOgCard,
 ): SatoriElement {
 	return createPageOgMarkup(iconDataUri, {
-		stamp: 'Read-only',
+		stamp: viewOgStamp(card.archived),
 		title: viewOgTitle(card.purpose),
 		lede: viewOgLede(card),
 	})

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -220,6 +220,7 @@ async function renderThreadView(
 				members: listed.members,
 				seats: listed.seats,
 				expiresAt: listed.thread.expires_at,
+				archived: listed.thread.archived_at != null,
 			}),
 			extraHead:
 				'<meta name="robots" content="noindex" /><meta name="referrer" content="no-referrer" />',

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -25,13 +25,12 @@ import {
 	privacyPage,
 	promptCard,
 	safetyNavLabel,
-	safetyOgImage,
-	safetyOgImageAlt,
 	safetyPath,
 	termsPage,
 	threadNotFoundPage,
 	threadViewPage,
 } from '#src/html.ts'
+import { threadViewOgPath, viewOgAlt } from '#src/og-pages.ts'
 import {
 	exampleHarborAgentId,
 	exampleMembers,
@@ -144,8 +143,6 @@ export async function renderPage(
 					title: safetyNavLabel,
 					description:
 						'Peer-channel security and privacy on kody.exchange — method, scores, and what a watch link grants.',
-					ogImage: safetyOgImage,
-					ogImageAlt: safetyOgImageAlt,
 					body: researchPage(),
 				}),
 			)
@@ -217,6 +214,13 @@ async function renderThreadView(
 			path: new URL(request.url).pathname,
 			title: listed.thread.purpose?.trim() || 'Thread',
 			description: 'Read-only thread on kody.exchange.',
+			ogImage: threadViewOgPath(viewToken),
+			ogImageAlt: viewOgAlt({
+				purpose: listed.thread.purpose,
+				members: listed.members,
+				seats: listed.seats,
+				expiresAt: listed.thread.expires_at,
+			}),
 			extraHead:
 				'<meta name="robots" content="noindex" /><meta name="referrer" content="no-referrer" />',
 			mainClass: 'thread-page',

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -927,6 +927,32 @@ export async function listMessages(input: {
 	}
 }
 
+export async function getThreadViewCard(input: {
+	db: D1Database
+	viewToken: string
+	now?: number
+}): Promise<
+	| DomainError
+	| DomainOk<{
+			thread: ThreadRow
+			members: Array<ThreadMemberView>
+			seats: number
+	  }>
+> {
+	const now = input.now ?? Date.now()
+	const thread = await getThreadByViewToken(input.db, input.viewToken)
+	if (!thread || thread.expires_at <= now) {
+		return fail(404, 'thread_not_found', 'Thread not found or expired.')
+	}
+	const planName = await planForOwner(input.db, thread.owner_user_id)
+	return {
+		ok: true,
+		thread,
+		members: await listThreadMembers(input.db, thread.id),
+		seats: getPlan(planName).liveAgents,
+	}
+}
+
 export async function listMessagesForView(input: {
 	db: D1Database
 	viewToken: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
View pages previously reused the homepage koala card. They now get a dynamic read-only card (purpose + roster), and every other public page gets its own Satori image too.

## What

- Catalog of page cards: `/`, `/example`, `/pricing`, `/docs`, `/safety`, `/privacy`, `/terms`
- Live watch pages: `GET /t/{kx_view_…}/og.png` (and `.jpg`) from purpose, members, seats, and a day-precision expiry
- Archived rooms use an **Archived** stamp and a new cache key
- HTML `og:image` points at the matching card
- Missing/expired rooms 404 **before** the renderer loads
- Rendered PNGs are cached in the Cache API; responses send `Cache-Control: public, max-age=3600` (pages) or `max-age=300` (views). A join or archive changes the cache key.

## Why not a second worker

Satori was already a lazy import on crawler-only routes. This keeps that split: HTML/API isolates do not load wasm. A dedicated OG worker is the fallback if isolate CPU or bundle size becomes a measured problem — not the first move.

## Out of scope

Message bodies and join tokens never appear on the card.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22822360-127d-4069-bd87-cc1cd550393c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22822360-127d-4069-bd87-cc1cd550393c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

