### PR TITLE
Upgrade Node toolchain to Node 26

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 🟢 Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
           cache: npm
 
       - name: 📥 Install

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ jobs:
       - name: 🟢 Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
           cache: npm
 
       - name: 📥 Install

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^5.20260801.1",
-				"@types/node": "^24.3.0",
+				"@types/node": "^26.2.0",
 				"oxfmt": "^0.62.0",
 				"oxlint": "^1.77.0",
 				"typescript": "^5.9.2",
@@ -23,7 +23,7 @@
 				"wrangler": "^4.118.0"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=26"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -2293,13 +2293,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.13.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-			"integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+			"integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.18.0"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -3479,9 +3479,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^5.20260801.1",
-		"@types/node": "^24.3.0",
+		"@types/node": "^26.2.0",
 		"oxfmt": "^0.62.0",
 		"oxlint": "^1.77.0",
 		"typescript": "^5.9.2",
@@ -34,7 +34,7 @@
 		"wrangler": "^4.118.0"
 	},
 	"engines": {
-		"node": ">=22"
+		"node": ">=26"
 	},
 	"allowScripts": {
 		"esbuild@0.28.1": true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Upgrades the build/CI toolchain from Node 22 to Node 26.

- `package.json`: `engines.node` `>=22` → `>=26`
- `package.json`: `@types/node` `^24.3.0` → `^26.2.0` (the `ts5.9`-tagged release, matching the pinned TypeScript 5.9)
- `package-lock.json`: refreshed on Node 26 (`@types/node` → `26.2.0`, transitive `undici-types` → `8.3.0`)
- `.github/workflows/validate.yml` and `.github/workflows/deploy.yml`: `node-version: 22` → `26`

The Worker runtime is `workerd` (unaffected); Node only powers the local/CI toolchain (wrangler, tsc, vitest, oxlint/oxfmt), all of which support Node 26.

## Testing

Validated locally against a real Node 26.7.0 install (npm 11.19.0):

- `npm ci` — clean install, 0 vulnerabilities
- `npm run validate` — format check, lint, typecheck, and tests all pass (72 tests across 19 files)
- `wrangler dev` boots and `GET /health` returns `{"ok":true,"commit":"dev",...}`
- End-to-end `POST /v1/threads` on a clean local D1 returns `ok:true` with a `kx_live_` token (guest plan), and the guest-per-IP limit fires correctly when a live thread already exists — confirming D1 + Durable Object access works under Node 26.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3a47457-a363-4703-bae4-ed0ff433ce95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3a47457-a363-4703-bae4-ed0ff433ce95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Node.js version to 26.
  * Updated deployment and validation processes to run on Node.js 26.
  * Updated Node.js type definitions to match the new runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->