### PR TITLE
Add Epic-style RBAC and an operator usage page

### DIFF
--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -24,3 +24,4 @@ Stable nouns. Not a changelog.
 - `kody-exchange-blobs` is this product's R2 bucket. Do not use `kody-email-blobs` (that belongs to kody.codes email attachments).
 - Expired threads cascade-delete members, guest agents, and messages.
 - `max` is operator-granted (`kentcdodds`, or `plan_grants`). Do not list it on public pricing, homepage, or agent docs. Stripe must not overwrite it.
+- Operator insights (`/admin`, `/admin.json`, `kentcdodds` only) are counts and account/thread metadata. They do not include message bodies, tokens, or guest IPs.

--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -24,6 +24,6 @@ Stable nouns. Not a changelog.
 - `kody-exchange-blobs` is this product's R2 bucket. Do not use `kody-email-blobs` (that belongs to kody.codes email attachments).
 - Expired threads cascade-delete members, guest agents, and messages.
 - Authorization is RBAC: users have roles, roles have `action:entity:access` permissions, and a user's permissions are the union of their roles. The `user` role is `*:own`. The `admin` role is `*:own` plus `*:any`. Checks are explicit (`userHasPermission(user, 'read:user:any')`). Roles load fresh per request and fail closed.
-- There is no runtime path that grants `admin`. The first admin is bootstrapped when GitHub login `kentcdodds` signs in (or by SQL).
+- There is no runtime path that grants `admin`. Assign it with SQL against `user_roles`.
 - `max` is granted by `update:user:any` (or a stored `plan_grants` row). Do not list it on public pricing, homepage, or agent docs. Stripe must not overwrite it.
 - Operator insights (`/admin`, `/admin.json`) require `read:user:any`. They are counts and account/thread metadata. They do not include message bodies, tokens, or guest IPs.

--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -23,5 +23,7 @@ Stable nouns. Not a changelog.
 - Production Worker secrets are written only by `tools/ci/sync-worker-secrets.ts` during deploy. Do not `wrangler secret put` by hand.
 - `kody-exchange-blobs` is this product's R2 bucket. Do not use `kody-email-blobs` (that belongs to kody.codes email attachments).
 - Expired threads cascade-delete members, guest agents, and messages.
-- `max` is operator-granted (`kentcdodds`, or `plan_grants`). Do not list it on public pricing, homepage, or agent docs. Stripe must not overwrite it.
-- Operator insights (`/admin`, `/admin.json`, `kentcdodds` only) are counts and account/thread metadata. They do not include message bodies, tokens, or guest IPs.
+- Authorization is RBAC: users have roles, roles have `action:entity:access` permissions, and a user's permissions are the union of their roles. The `user` role is `*:own`. The `admin` role is `*:own` plus `*:any`. Checks are explicit (`userHasPermission(user, 'read:user:any')`). Roles load fresh per request and fail closed.
+- There is no runtime path that grants `admin`. The first admin is bootstrapped when GitHub login `kentcdodds` signs in (or by SQL).
+- `max` is granted by `update:user:any` (or a stored `plan_grants` row). Do not list it on public pricing, homepage, or agent docs. Stripe must not overwrite it.
+- Operator insights (`/admin`, `/admin.json`) require `read:user:any`. They are counts and account/thread metadata. They do not include message bodies, tokens, or guest IPs.

--- a/migrations/0007_rbac.sql
+++ b/migrations/0007_rbac.sql
@@ -1,0 +1,71 @@
+CREATE TABLE roles (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL UNIQUE,
+	description TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE permissions (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	action TEXT NOT NULL,
+	entity TEXT NOT NULL,
+	access TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	UNIQUE (action, entity, access)
+);
+
+CREATE TABLE role_permissions (
+	role_id INTEGER NOT NULL REFERENCES roles (id) ON DELETE CASCADE,
+	permission_id INTEGER NOT NULL REFERENCES permissions (id) ON DELETE CASCADE,
+	PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE user_roles (
+	user_id TEXT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+	role_id INTEGER NOT NULL REFERENCES roles (id) ON DELETE CASCADE,
+	PRIMARY KEY (user_id, role_id)
+);
+
+INSERT INTO roles (name, description) VALUES
+	('user', 'Default role for every account'),
+	('admin', 'Operator role');
+
+INSERT INTO permissions (action, entity, access) VALUES
+	('create', 'user', 'own'),
+	('read', 'user', 'own'),
+	('update', 'user', 'own'),
+	('delete', 'user', 'own'),
+	('create', 'role', 'own'),
+	('read', 'role', 'own'),
+	('update', 'role', 'own'),
+	('delete', 'role', 'own'),
+	('create', 'user', 'any'),
+	('read', 'user', 'any'),
+	('update', 'user', 'any'),
+	('delete', 'user', 'any'),
+	('create', 'role', 'any'),
+	('read', 'role', 'any'),
+	('update', 'role', 'any'),
+	('delete', 'role', 'any');
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+INNER JOIN permissions p ON p.access = 'own'
+WHERE r.name = 'user';
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+INNER JOIN permissions p
+WHERE r.name = 'admin';
+
+INSERT INTO user_roles (user_id, role_id)
+SELECT u.id, r.id
+FROM users u
+INNER JOIN roles r ON r.name = 'user';
+
+INSERT INTO user_roles (user_id, role_id)
+SELECT u.id, r.id
+FROM users u
+INNER JOIN roles r ON r.name = 'admin'
+WHERE lower(u.login) = 'kentcdodds';

--- a/migrations/0007_rbac.sql
+++ b/migrations/0007_rbac.sql
@@ -63,9 +63,3 @@ INSERT INTO user_roles (user_id, role_id)
 SELECT u.id, r.id
 FROM users u
 INNER JOIN roles r ON r.name = 'user';
-
-INSERT INTO user_roles (user_id, role_id)
-SELECT u.id, r.id
-FROM users u
-INNER JOIN roles r ON r.name = 'admin'
-WHERE lower(u.login) = 'kentcdodds';

--- a/src/admin.node.test.ts
+++ b/src/admin.node.test.ts
@@ -184,7 +184,7 @@ test('operator can open admin html and json; others cannot', async () => {
 	expect(body.users.total).toBe(2)
 })
 
-test('admin nav is only in the operator chrome', async () => {
+test('admin nav follows read:user:any, not the GitHub login', async () => {
 	const env = createTestEnv()
 	const operator = await createSignedInUser(env, {
 		id: 'usr_op',

--- a/src/admin.node.test.ts
+++ b/src/admin.node.test.ts
@@ -18,6 +18,7 @@ test('admin insights count users, rooms, and messages without bodies', async () 
 		email: 'me@kentcdodds.com',
 		plan: 'max',
 		created_at: now - 86_400_000,
+		roles: ['admin'],
 	})
 	const friend = await createSignedInUser(env, {
 		id: 'usr_friend',
@@ -124,6 +125,7 @@ test('operator can open admin html and json; others cannot', async () => {
 		login: 'kentcdodds',
 		email: 'me@kentcdodds.com',
 		plan: 'max',
+		roles: ['admin'],
 	})
 	const stranger = await createSignedInUser(env, {
 		id: 'usr_stranger',
@@ -191,6 +193,7 @@ test('admin nav follows read:user:any, not the GitHub login', async () => {
 		github_id: '99',
 		login: 'kentcdodds',
 		plan: 'max',
+		roles: ['admin'],
 	})
 	const stranger = await createSignedInUser(env, {
 		id: 'usr_stranger',

--- a/src/admin.node.test.ts
+++ b/src/admin.node.test.ts
@@ -1,0 +1,216 @@
+import { expect, test } from 'vitest'
+import { handleRequest } from '#src/index.ts'
+import { loadAdminInsights } from '#src/admin.ts'
+import { run } from '#src/db.ts'
+import {
+	createSignedInUser,
+	createTestEnv,
+	request,
+} from '#src/test-support.ts'
+
+test('admin insights count users, rooms, and messages without bodies', async () => {
+	const env = createTestEnv()
+	const now = Date.UTC(2026, 7, 16, 18, 0, 0)
+	await createSignedInUser(env, {
+		id: 'usr_op',
+		github_id: '99',
+		login: 'kentcdodds',
+		email: 'me@kentcdodds.com',
+		plan: 'max',
+		created_at: now - 86_400_000,
+	})
+	const friend = await createSignedInUser(env, {
+		id: 'usr_friend',
+		github_id: '7',
+		login: 'someoneelse',
+		name: 'Sam',
+		email: 'sam@example.com',
+		plan: 'free',
+		created_at: now - 3_600_000,
+	})
+
+	const owned = await handleRequest(
+		request('/account/threads', {
+			method: 'POST',
+			headers: {
+				cookie: friend.cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf: friend.csrf,
+				purpose: 'pair on the billing bug',
+				name: 'cursor',
+			}),
+		}),
+		env,
+	)
+	expect(owned.status).toBe(303)
+
+	const guest = await handleRequest(
+		request('/v1/threads', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'cf-connecting-ip': '203.0.113.9',
+			},
+			body: JSON.stringify({ purpose: 'guest demo', name: 'guest-agent' }),
+		}),
+		env,
+	)
+	const guestBody = (await guest.json()) as { token: string }
+	const secret = await handleRequest(
+		request('/v1/messages', {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${guestBody.token}`,
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({
+				body: { text: 'super-secret-peer-body-do-not-leak' },
+			}),
+		}),
+		env,
+	)
+	expect(secret.status).toBe(200)
+
+	await run(
+		env.DB,
+		`INSERT INTO blobs (id, user_id, thread_id, content_type, byte_size, created_at)
+		 VALUES (?, ?, NULL, 'text/plain', ?, ?)`,
+		'bl_1',
+		'usr_friend',
+		2048,
+		now,
+	)
+
+	const insights = await loadAdminInsights(env.DB, now)
+	expect(insights.users.total).toBe(2)
+	expect(insights.users.byPlan).toEqual({ free: 1, pro: 0, max: 1 })
+	expect(insights.threads.liveOwned).toBe(1)
+	expect(insights.threads.liveGuest).toBe(1)
+	expect(insights.liveGuestIps).toBe(1)
+	expect(insights.blobs.count).toBe(1)
+	expect(insights.blobs.bytes).toBe(2048)
+	expect(insights.messages.all).toBeGreaterThanOrEqual(2)
+	expect(insights.messages.thisMonthGuest).toBeGreaterThanOrEqual(1)
+	expect(insights.recentUsers.map((user) => user.login)).toEqual([
+		'someoneelse',
+		'kentcdodds',
+	])
+	expect(
+		insights.recentThreads.some(
+			(thread) => thread.purpose === 'pair on the billing bug' && !thread.guest,
+		),
+	).toBe(true)
+	expect(
+		insights.recentThreads.some(
+			(thread) => thread.purpose === 'guest demo' && thread.guest,
+		),
+	).toBe(true)
+	expect(JSON.stringify(insights)).not.toContain(
+		'super-secret-peer-body-do-not-leak',
+	)
+	expect(JSON.stringify(insights)).not.toContain('203.0.113.9')
+	expect(JSON.stringify(insights)).not.toContain('kx_live_')
+	expect(insights.dailyMessages[0]?.day).toBe('2026-08-16')
+	expect(insights.dailyMessages).toHaveLength(14)
+})
+
+test('operator can open admin html and json; others cannot', async () => {
+	const env = createTestEnv()
+	const operator = await createSignedInUser(env, {
+		id: 'usr_op',
+		github_id: '99',
+		login: 'kentcdodds',
+		email: 'me@kentcdodds.com',
+		plan: 'max',
+	})
+	const stranger = await createSignedInUser(env, {
+		id: 'usr_stranger',
+		github_id: '8',
+		login: 'jane',
+	})
+
+	const signedOut = await handleRequest(request('/admin'), env)
+	expect(signedOut.status).toBe(302)
+	expect(signedOut.headers.get('location')).toBe(
+		'https://kody.exchange/auth/github?next=%2Fadmin',
+	)
+
+	const signedOutJson = await handleRequest(request('/admin.json'), env)
+	expect(signedOutJson.status).toBe(401)
+
+	const denied = await handleRequest(
+		request('/admin', { headers: { cookie: stranger.cookie } }),
+		env,
+	)
+	expect(denied.status).toBe(404)
+	expect(denied.headers.get('content-type')).toContain('application/json')
+	expect(await denied.text()).not.toContain('Usage')
+
+	const deniedJson = await handleRequest(
+		request('/admin.json', { headers: { cookie: stranger.cookie } }),
+		env,
+	)
+	expect(deniedJson.status).toBe(404)
+
+	const page = await handleRequest(
+		request('/admin', { headers: { cookie: operator.cookie } }),
+		env,
+	)
+	expect(page.status).toBe(200)
+	const html = await page.text()
+	expect(html).toContain('Usage')
+	expect(html).toContain('noindex')
+	expect(html).toContain('@kentcdodds')
+	expect(html).toContain('@jane')
+	expect(html).toContain('me@kentcdodds.com')
+	expect(html).toContain('href="/admin"')
+	expect(html).toContain('aria-current="page"')
+	expect(html).toContain('/admin.json')
+	expect(html).not.toContain('action="/account/grants"')
+
+	const snapshot = await handleRequest(
+		request('/admin.json', { headers: { cookie: operator.cookie } }),
+		env,
+	)
+	expect(snapshot.status).toBe(200)
+	expect(snapshot.headers.get('access-control-allow-origin')).toBeNull()
+	const body = (await snapshot.json()) as {
+		ok: boolean
+		users: { total: number }
+	}
+	expect(body.ok).toBe(true)
+	expect(body.users.total).toBe(2)
+})
+
+test('admin nav is only in the operator chrome', async () => {
+	const env = createTestEnv()
+	const operator = await createSignedInUser(env, {
+		id: 'usr_op',
+		github_id: '99',
+		login: 'kentcdodds',
+		plan: 'max',
+	})
+	const stranger = await createSignedInUser(env, {
+		id: 'usr_stranger',
+		github_id: '8',
+		login: 'jane',
+	})
+
+	const operatorHtml = await (
+		await handleRequest(
+			request('/account', { headers: { cookie: operator.cookie } }),
+			env,
+		)
+	).text()
+	expect(operatorHtml).toContain('href="/admin"')
+
+	const strangerHtml = await (
+		await handleRequest(
+			request('/account', { headers: { cookie: stranger.cookie } }),
+			env,
+		)
+	).text()
+	expect(strangerHtml).not.toContain('href="/admin"')
+})

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,0 +1,480 @@
+import { all, first } from '#src/db.ts'
+import { escapeHtml } from '#src/html.ts'
+import { accountPlan, yearMonth, type AccountPlanName } from '#src/limits.ts'
+
+export const adminPath = '/admin'
+export const adminJsonPath = '/admin.json'
+export const adminRecentUserLimit = 50
+export const adminRecentThreadLimit = 40
+export const adminDailyWindowDays = 14
+
+export type AdminPlanCounts = Record<AccountPlanName, number>
+
+export type AdminUserInsight = {
+	login: string
+	name: string | null
+	email: string | null
+	plan: AccountPlanName
+	createdAt: string
+	liveThreads: number
+	messagesThisMonth: number
+}
+
+export type AdminThreadInsight = {
+	id: string
+	purpose: string | null
+	ownerLogin: string | null
+	guest: boolean
+	memberCount: number
+	createdAt: string
+	expiresAt: string
+	archived: boolean
+	lastMessageAt: string | null
+}
+
+export type AdminDayCount = {
+	day: string
+	count: number
+}
+
+export type AdminInsights = {
+	generatedAt: string
+	users: {
+		total: number
+		byPlan: AdminPlanCounts
+	}
+	threads: {
+		liveOwned: number
+		liveGuest: number
+		archivedUnexpired: number
+		remaining: number
+	}
+	messages: {
+		all: number
+		thisMonth: number
+		thisMonthAccount: number
+		thisMonthGuest: number
+	}
+	blobs: {
+		count: number
+		bytes: number
+	}
+	liveAgents: number
+	liveGuestIps: number
+	recentUsers: Array<AdminUserInsight>
+	recentThreads: Array<AdminThreadInsight>
+	dailyMessages: Array<AdminDayCount>
+}
+
+type CountRow = { n: number | string | null }
+type PlanRow = { plan: string; n: number | string | null }
+type MonthSplitRow = {
+	account: number | string | null
+	guest: number | string | null
+}
+type BlobRow = { n: number | string | null; bytes: number | string | null }
+type UserRow = {
+	login: string
+	name: string | null
+	email: string | null
+	plan: string
+	created_at: number
+	live_threads: number | string | null
+	messages_this_month: number | string | null
+}
+type ThreadRow = {
+	id: string
+	purpose: string | null
+	owner_login: string | null
+	created_at: number
+	expires_at: number
+	archived_at: number | null
+	member_count: number | string | null
+	last_message_at: number | string | null
+}
+type DayRow = { day: string; n: number | string | null }
+
+function asCount(value: number | string | null | undefined) {
+	return Number(value ?? 0)
+}
+
+function iso(ms: number) {
+	return new Date(ms).toISOString()
+}
+
+function utcDayKey(ms: number) {
+	return new Date(ms).toISOString().slice(0, 10)
+}
+
+function emptyPlanCounts(): AdminPlanCounts {
+	return { free: 0, pro: 0, max: 0 }
+}
+
+async function count(db: D1Database, sql: string, ...params: Array<unknown>) {
+	const row = await first<CountRow>(db, sql, ...params)
+	return asCount(row?.n)
+}
+
+function lastUtcDays(now: number, days: number) {
+	const keys: Array<string> = []
+	const start = Date.UTC(
+		new Date(now).getUTCFullYear(),
+		new Date(now).getUTCMonth(),
+		new Date(now).getUTCDate(),
+	)
+	for (let i = 0; i < days; i++) {
+		keys.push(utcDayKey(start - i * 24 * 60 * 60 * 1000))
+	}
+	return keys
+}
+
+/**
+ * Operator snapshot. Counts and metadata only — never message bodies, tokens,
+ * or guest IPs.
+ */
+export async function loadAdminInsights(
+	db: D1Database,
+	now = Date.now(),
+): Promise<AdminInsights> {
+	const month = yearMonth(now)
+	const sinceDaily = now - adminDailyWindowDays * 24 * 60 * 60 * 1000
+	const [
+		usersTotal,
+		planRows,
+		liveOwned,
+		liveGuest,
+		archivedUnexpired,
+		threadsRemaining,
+		messagesAll,
+		monthSplit,
+		blobRow,
+		liveAgents,
+		liveGuestIps,
+		recentUserRows,
+		recentThreadRows,
+		dailyRows,
+	] = await Promise.all([
+		count(db, 'SELECT COUNT(*) AS n FROM users'),
+		all<PlanRow>(db, 'SELECT plan, COUNT(*) AS n FROM users GROUP BY plan'),
+		count(
+			db,
+			`SELECT COUNT(*) AS n FROM threads
+			 WHERE owner_user_id IS NOT NULL AND expires_at > ? AND archived_at IS NULL`,
+			now,
+		),
+		count(
+			db,
+			`SELECT COUNT(*) AS n FROM threads
+			 WHERE owner_user_id IS NULL AND expires_at > ? AND archived_at IS NULL`,
+			now,
+		),
+		count(
+			db,
+			`SELECT COUNT(*) AS n FROM threads
+			 WHERE expires_at > ? AND archived_at IS NOT NULL`,
+			now,
+		),
+		count(db, 'SELECT COUNT(*) AS n FROM threads'),
+		count(db, 'SELECT COUNT(*) AS n FROM messages'),
+		first<MonthSplitRow>(
+			db,
+			`SELECT
+				 COALESCE(SUM(CASE WHEN owner_key LIKE 'user:%' THEN message_count ELSE 0 END), 0) AS account,
+				 COALESCE(SUM(CASE WHEN owner_key LIKE 'guest:%' THEN message_count ELSE 0 END), 0) AS guest
+			 FROM usage_months
+			 WHERE yyyymm = ?`,
+			month,
+		),
+		first<BlobRow>(
+			db,
+			'SELECT COUNT(*) AS n, COALESCE(SUM(byte_size), 0) AS bytes FROM blobs',
+		),
+		count(db, 'SELECT COUNT(*) AS n FROM agents WHERE revoked_at IS NULL'),
+		count(
+			db,
+			`SELECT COUNT(DISTINCT creator_ip) AS n FROM threads
+			 WHERE owner_user_id IS NULL
+			   AND creator_ip IS NOT NULL
+			   AND expires_at > ?
+			   AND archived_at IS NULL`,
+			now,
+		),
+		all<UserRow>(
+			db,
+			`SELECT u.login, u.name, u.email, u.plan, u.created_at,
+				 (
+					 SELECT COUNT(*) FROM threads t
+					 WHERE t.owner_user_id = u.id AND t.expires_at > ? AND t.archived_at IS NULL
+				 ) AS live_threads,
+				 COALESCE((
+					 SELECT um.message_count FROM usage_months um
+					 WHERE um.owner_key = 'user:' || u.id AND um.yyyymm = ?
+				 ), 0) AS messages_this_month
+			 FROM users u
+			 ORDER BY u.created_at DESC
+			 LIMIT ?`,
+			now,
+			month,
+			adminRecentUserLimit,
+		),
+		all<ThreadRow>(
+			db,
+			`SELECT t.id, t.purpose, u.login AS owner_login, t.created_at, t.expires_at,
+				 t.archived_at,
+				 (SELECT COUNT(*) FROM thread_members m WHERE m.thread_id = t.id) AS member_count,
+				 (SELECT MAX(msg.created_at) FROM messages msg WHERE msg.thread_id = t.id) AS last_message_at
+			 FROM threads t
+			 LEFT JOIN users u ON u.id = t.owner_user_id
+			 WHERE t.expires_at > ?
+			 ORDER BY t.created_at DESC
+			 LIMIT ?`,
+			now,
+			adminRecentThreadLimit,
+		),
+		all<DayRow>(
+			db,
+			`SELECT strftime('%Y-%m-%d', created_at / 1000, 'unixepoch') AS day, COUNT(*) AS n
+			 FROM messages
+			 WHERE created_at >= ?
+			 GROUP BY day
+			 ORDER BY day DESC`,
+			sinceDaily,
+		),
+	])
+
+	const byPlan = emptyPlanCounts()
+	for (const row of planRows) {
+		const plan = accountPlan(row.plan)
+		byPlan[plan] += asCount(row.n)
+	}
+
+	const thisMonthAccount = asCount(monthSplit?.account)
+	const thisMonthGuest = asCount(monthSplit?.guest)
+	const dailyByDay = new Map(
+		dailyRows.map((row) => [row.day, asCount(row.n)] as const),
+	)
+
+	return {
+		generatedAt: iso(now),
+		users: { total: usersTotal, byPlan },
+		threads: {
+			liveOwned,
+			liveGuest,
+			archivedUnexpired,
+			remaining: threadsRemaining,
+		},
+		messages: {
+			all: messagesAll,
+			thisMonth: thisMonthAccount + thisMonthGuest,
+			thisMonthAccount,
+			thisMonthGuest,
+		},
+		blobs: {
+			count: asCount(blobRow?.n),
+			bytes: asCount(blobRow?.bytes),
+		},
+		liveAgents,
+		liveGuestIps,
+		recentUsers: recentUserRows.map((row) => ({
+			login: row.login,
+			name: row.name,
+			email: row.email,
+			plan: accountPlan(row.plan),
+			createdAt: iso(row.created_at),
+			liveThreads: asCount(row.live_threads),
+			messagesThisMonth: asCount(row.messages_this_month),
+		})),
+		recentThreads: recentThreadRows.map((row) => ({
+			id: row.id,
+			purpose: row.purpose,
+			ownerLogin: row.owner_login,
+			guest: row.owner_login == null,
+			memberCount: asCount(row.member_count),
+			createdAt: iso(row.created_at),
+			expiresAt: iso(row.expires_at),
+			archived: row.archived_at != null,
+			lastMessageAt:
+				row.last_message_at == null ? null : iso(asCount(row.last_message_at)),
+		})),
+		dailyMessages: lastUtcDays(now, adminDailyWindowDays).map((day) => ({
+			day,
+			count: dailyByDay.get(day) ?? 0,
+		})),
+	}
+}
+
+function formatNumber(value: number) {
+	return value.toLocaleString('en-US')
+}
+
+function formatBytes(bytes: number) {
+	if (bytes < 1024) return `${formatNumber(bytes)} B`
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+	if (bytes < 1024 * 1024 * 1024)
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+function stamp(value: string | null) {
+	if (!value) return '—'
+	return `${value.replace('T', ' ').slice(0, 16)} UTC`
+}
+
+function statCard(label: string, value: string, hint: string) {
+	return `<article class="card">
+		<h3>${escapeHtml(label)}</h3>
+		<p class="price">${escapeHtml(value)}</p>
+		<p class="tiny">${escapeHtml(hint)}</p>
+	</article>`
+}
+
+function usersTable(users: Array<AdminUserInsight>) {
+	if (users.length === 0) {
+		return '<p class="muted">No signed-in users yet.</p>'
+	}
+	const rows = users
+		.map(
+			(user) => `<tr>
+			<td>@${escapeHtml(user.login)}</td>
+			<td>${escapeHtml(user.name ?? '—')}</td>
+			<td>${escapeHtml(user.email ?? '—')}</td>
+			<td>${escapeHtml(user.plan)}</td>
+			<td class="num">${escapeHtml(formatNumber(user.liveThreads))}</td>
+			<td class="num">${escapeHtml(formatNumber(user.messagesThisMonth))}</td>
+			<td>${escapeHtml(stamp(user.createdAt))}</td>
+		</tr>`,
+		)
+		.join('')
+	return `<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th>GitHub</th>
+					<th>Name</th>
+					<th>Email</th>
+					<th>Plan</th>
+					<th class="num">Live threads</th>
+					<th class="num">Msgs this month</th>
+					<th>Signed up</th>
+				</tr>
+			</thead>
+			<tbody>${rows}</tbody>
+		</table>
+	</div>`
+}
+
+function threadsTable(threads: Array<AdminThreadInsight>) {
+	if (threads.length === 0) {
+		return '<p class="muted">No unexpired threads.</p>'
+	}
+	const rows = threads
+		.map((thread) => {
+			const owner = thread.guest
+				? 'guest'
+				: `@${thread.ownerLogin ?? 'unknown'}`
+			const purpose = thread.purpose?.trim() || 'Untitled'
+			const state = thread.archived ? 'archived' : 'live'
+			return `<tr>
+			<td>${escapeHtml(purpose)}</td>
+			<td>${escapeHtml(owner)}</td>
+			<td class="num">${escapeHtml(formatNumber(thread.memberCount))}</td>
+			<td>${escapeHtml(state)}</td>
+			<td>${escapeHtml(stamp(thread.lastMessageAt))}</td>
+			<td>${escapeHtml(stamp(thread.createdAt))}</td>
+		</tr>`
+		})
+		.join('')
+	return `<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th>Purpose</th>
+					<th>Owner</th>
+					<th class="num">Members</th>
+					<th>State</th>
+					<th>Last message</th>
+					<th>Created</th>
+				</tr>
+			</thead>
+			<tbody>${rows}</tbody>
+		</table>
+	</div>`
+}
+
+function dailyTable(days: Array<AdminDayCount>) {
+	const rows = days
+		.map(
+			(day) => `<tr>
+			<td>${escapeHtml(day.day)}</td>
+			<td class="num">${escapeHtml(formatNumber(day.count))}</td>
+		</tr>`,
+		)
+		.join('')
+	return `<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th>UTC day</th>
+					<th class="num">Messages</th>
+				</tr>
+			</thead>
+			<tbody>${rows}</tbody>
+		</table>
+	</div>`
+}
+
+export function adminPage(insights: AdminInsights) {
+	const plans = insights.users.byPlan
+	return `
+	<p class="stamp">Operator</p>
+	<h1>Usage</h1>
+	<p class="lede">Signed-in accounts, live rooms, and message volume. Message bodies, tokens, and guest IPs stay off this page.</p>
+	<p class="tiny">Snapshot ${escapeHtml(stamp(insights.generatedAt))}. Same numbers as JSON at <code>${escapeHtml(adminJsonPath)}</code>.</p>
+	<div class="stats">
+		${statCard(
+			'Users',
+			formatNumber(insights.users.total),
+			`${formatNumber(plans.free)} free · ${formatNumber(plans.pro)} pro · ${formatNumber(plans.max)} max`,
+		)}
+		${statCard(
+			'Live threads',
+			formatNumber(insights.threads.liveOwned + insights.threads.liveGuest),
+			`${formatNumber(insights.threads.liveOwned)} owned · ${formatNumber(insights.threads.liveGuest)} guest`,
+		)}
+		${statCard(
+			'Messages this month',
+			formatNumber(insights.messages.thisMonth),
+			`${formatNumber(insights.messages.thisMonthAccount)} account · ${formatNumber(insights.messages.thisMonthGuest)} guest`,
+		)}
+		${statCard(
+			'Messages all time',
+			formatNumber(insights.messages.all),
+			`${formatNumber(insights.threads.remaining)} threads still in D1`,
+		)}
+		${statCard(
+			'Live agents',
+			formatNumber(insights.liveAgents),
+			`${formatNumber(insights.liveGuestIps)} guest IPs with a live room`,
+		)}
+		${statCard(
+			'Blobs',
+			formatNumber(insights.blobs.count),
+			formatBytes(insights.blobs.bytes),
+		)}
+	</div>
+	${
+		insights.threads.archivedUnexpired === 0
+			? ''
+			: `<p class="tiny">${escapeHtml(formatNumber(insights.threads.archivedUnexpired))} archived rooms are still within retention.</p>`
+	}
+	<h2>Accounts</h2>
+	${usersTable(insights.recentUsers)}
+	<h2>Unexpired threads</h2>
+	<p class="tiny">Purposes are the one-liners people typed. This list does not include watch links or tokens.</p>
+	${threadsTable(insights.recentThreads)}
+	<h2>Messages by day</h2>
+	<p class="tiny">Includes system join lines. Last ${escapeHtml(String(adminDailyWindowDays))} UTC days.</p>
+	${dailyTable(insights.dailyMessages)}
+	<p class="tiny">Hidden plan grants still live on <a href="/account">Threads</a>.</p>
+	`
+}

--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -333,7 +333,10 @@ test('guest thread: create, join, send, poll, and health', async () => {
 	expect(oldJoin.status).toBe(404)
 
 	const robots = await handleRequest(request('/robots.txt'), env)
-	expect(await robots.text()).toContain('Disallow: /t/')
+	const robotsText = await robots.text()
+	expect(robotsText).toContain('Disallow: /t/')
+	expect(robotsText).toContain('Disallow: /account')
+	expect(robotsText).toContain('Disallow: /admin')
 })
 
 test('view host prompt token can send on that thread but cannot open another', async () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -239,7 +239,7 @@ export async function finishGithubOAuth(request: Request, env: AppEnv) {
 			now,
 		)
 	}
-	await ensureAccountRoles(env.DB, userId, profile.login)
+	await ensureAccountRoles(env.DB, userId)
 	await applyGrantedPlan(env.DB, userId, profile.login)
 
 	const session = await signPayload(

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,6 +4,8 @@ import { type AppEnv, appBaseUrl } from '#src/env.ts'
 import { createId } from '#src/ids.ts'
 import { applyGrantedPlan } from '#src/grants.ts'
 import { accountPlan, type AccountPlanName } from '#src/limits.ts'
+import { type SessionUser } from '#src/permissions.ts'
+import { ensureAccountRoles, loadAccessOrEmpty } from '#src/permissions-db.ts'
 import { type UserRow } from '#src/threads.ts'
 
 const sessionCookie = 'kx_session'
@@ -74,10 +76,13 @@ export async function readSessionUser(request: Request, env: AppEnv) {
 		parsed.userId,
 	)
 	if (!user) return null
+	const access = await loadAccessOrEmpty(env.DB, user.id)
 	return {
 		...user,
 		plan: accountPlan(user.plan),
-	}
+		roles: access.roles,
+		permissions: access.permissions,
+	} satisfies SessionUser
 }
 
 export async function startGithubOAuth(request: Request, env: AppEnv) {
@@ -234,6 +239,7 @@ export async function finishGithubOAuth(request: Request, env: AppEnv) {
 			now,
 		)
 	}
+	await ensureAccountRoles(env.DB, userId, profile.login)
 	await applyGrantedPlan(env.DB, userId, profile.login)
 
 	const session = await signPayload(

--- a/src/grants.node.test.ts
+++ b/src/grants.node.test.ts
@@ -1,16 +1,18 @@
 import { expect, test } from 'vitest'
 import { applyGrantedPlan, grantMaxToLogin } from '#src/grants.ts'
 import { first, run } from '#src/db.ts'
+import { assignUserRole } from '#src/permissions-db.ts'
 import { createTestEnv } from '#src/test-support.ts'
 
-test('operator login and stored grants assign the hidden plan', async () => {
+test('admin role and stored grants assign the hidden plan', async () => {
 	const env = createTestEnv()
 	await run(
 		env.DB,
 		`INSERT INTO users (id, github_id, login, name, avatar_url, email, plan, created_at)
-		 VALUES ('usr_op', '1', 'kentcdodds', 'Kent', null, null, 'free', 1)`,
+		 VALUES ('usr_op', '1', 'sam', 'Sam', null, null, 'free', 1)`,
 	)
-	await applyGrantedPlan(env.DB, 'usr_op', 'KentCDodds')
+	await assignUserRole({ db: env.DB, userId: 'usr_op', roleName: 'admin' })
+	await applyGrantedPlan(env.DB, 'usr_op', 'Sam')
 	expect(
 		(
 			await first<{ plan: string }>(

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -15,7 +15,7 @@ export async function applyGrantedPlan(
 	login: string,
 ) {
 	const normalized = login.toLowerCase()
-	const access = await ensureAccountRoles(db, userId, login)
+	const access = await ensureAccountRoles(db, userId)
 	if (userHasRole(access, 'admin')) {
 		await run(db, 'UPDATE users SET plan = ? WHERE id = ?', 'max', userId)
 		await run(

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -1,5 +1,6 @@
 import { first, run } from '#src/db.ts'
-import { isOperatorLogin } from '#src/limits.ts'
+import { userHasRole } from '#src/permissions.ts'
+import { ensureAccountRoles } from '#src/permissions-db.ts'
 
 export function sanitizeGithubLogin(value: unknown) {
 	if (typeof value !== 'string') return null
@@ -14,7 +15,8 @@ export async function applyGrantedPlan(
 	login: string,
 ) {
 	const normalized = login.toLowerCase()
-	if (isOperatorLogin(normalized)) {
+	const access = await ensureAccountRoles(db, userId, login)
+	if (userHasRole(access, 'admin')) {
 		await run(db, 'UPDATE users SET plan = ? WHERE id = ?', 'max', userId)
 		await run(
 			db,

--- a/src/html.ts
+++ b/src/html.ts
@@ -2,7 +2,7 @@ import { githubOAuthConfigured } from '#src/auth.ts'
 import { type MessageEnvelope, type MessageKind } from '#src/envelope.ts'
 import { type AppEnv } from '#src/env.ts'
 import { examplePath } from '#src/example-thread.ts'
-import { plans } from '#src/limits.ts'
+import { isOperatorLogin, plans } from '#src/limits.ts'
 import {
 	defaultOgImage,
 	defaultOgImageAlt,
@@ -98,7 +98,12 @@ export function layout(input: {
 			<a href="${safetyPath}" ${ariaCurrent(input.path, safetyPath)}>${safetyNavLabel}</a>
 			${
 				signedIn
-					? `<a href="/account" ${ariaCurrent(input.path, '/account')}>Threads</a>
+					? `${
+							input.user && isOperatorLogin(input.user.login)
+								? `<a href="/admin" ${ariaCurrent(input.path, '/admin')}>Admin</a>
+						`
+								: ''
+						}<a href="/account" ${ariaCurrent(input.path, '/account')}>Threads</a>
 						<form method="post" action="/auth/logout"><button type="submit">Sign out</button></form>`
 					: githubOAuthConfigured(input.env)
 						? `<a class="btn ghost" href="/auth/github">Sign in with GitHub</a>`
@@ -165,6 +170,12 @@ nav form { margin: 0; }
 button, .btn { font-family: "IBM Plex Mono", monospace; background: var(--leaf); color: var(--on-leaf); border: 0; border-radius: 0 8px 8px 0; border-left: 4px solid var(--amber); padding: .55rem .9rem; cursor: pointer; text-decoration: none; display: inline-block; }
 .btn.ghost { background: transparent; color: var(--ink); border: 1px solid var(--line); border-left: 4px solid var(--leaf); }
 main { width: min(920px, calc(100% - 2rem)); margin: 2rem auto 3rem; flex: 1; }
+main.admin-page { width: min(1080px, calc(100% - 2rem)); }
+.stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; margin: 1.6rem 0; }
+.stats .card { margin: 0; }
+.stats .price { margin: .2rem 0; }
+.table-wrap { overflow-x: auto; }
+th.num, td.num { text-align: right; font-family: "IBM Plex Mono", monospace; }
 .hero { display: grid; grid-template-columns: 140px 1fr; gap: 1.4rem; align-items: center; }
 .hero img { width: 140px; height: 140px; }
 h1, h2, h3 { font-family: Fraunces, serif; font-weight: 700; letter-spacing: -0.02em; }

--- a/src/html.ts
+++ b/src/html.ts
@@ -2,7 +2,8 @@ import { githubOAuthConfigured } from '#src/auth.ts'
 import { type MessageEnvelope, type MessageKind } from '#src/envelope.ts'
 import { type AppEnv } from '#src/env.ts'
 import { examplePath } from '#src/example-thread.ts'
-import { isOperatorLogin, plans } from '#src/limits.ts'
+import { plans } from '#src/limits.ts'
+import { userHasPermission, type SessionUser } from '#src/permissions.ts'
 import {
 	defaultOgImage,
 	defaultOgImageAlt,
@@ -40,7 +41,7 @@ export function layout(input: {
 	title: string
 	description?: string
 	path: string
-	user: UserRow | null
+	user: SessionUser | UserRow | null
 	env: AppEnv
 	body: string
 	extraHead?: string
@@ -99,7 +100,7 @@ export function layout(input: {
 			${
 				signedIn
 					? `${
-							input.user && isOperatorLogin(input.user.login)
+							userHasPermission(input.user, 'read:user:any')
 								? `<a href="/admin" ${ariaCurrent(input.path, '/admin')}>Admin</a>
 						`
 								: ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,9 +65,12 @@ export async function handleRequest(
 	}
 
 	if (url.pathname === '/robots.txt') {
-		return new Response('User-agent: *\nAllow: /\nDisallow: /t/\n', {
-			headers: { 'content-type': 'text/plain; charset=utf-8' },
-		})
+		return new Response(
+			'User-agent: *\nAllow: /\nDisallow: /t/\nDisallow: /account\nDisallow: /admin\n',
+			{
+				headers: { 'content-type': 'text/plain; charset=utf-8' },
+			},
+		)
 	}
 
 	const viewOgToken = viewTokenForOgPath(url.pathname)

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -88,10 +88,6 @@ export function accountPlan(plan: string): AccountPlanName {
 	}
 }
 
-export function isOperatorLogin(login: string) {
-	return login.toLowerCase() === 'kentcdodds'
-}
-
 export function getPlan(name: PlanName): PlanLimits {
 	switch (name) {
 		case 'guest':

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -99,6 +99,7 @@ test('operator can grant the hidden plan; public pages do not name it', async ()
 		github_id: '99',
 		login: 'kentcdodds',
 		plan: 'max',
+		roles: ['admin'],
 	})
 	const page = await handleRequest(
 		request('/account', { headers: { cookie: operator.cookie } }),

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -46,7 +46,8 @@ import {
 	adminPath,
 	loadAdminInsights,
 } from '#src/admin.ts'
-import { getPlan, isOperatorLogin } from '#src/limits.ts'
+import { getPlan } from '#src/limits.ts'
+import { userHasPermission, type SessionUser } from '#src/permissions.ts'
 import { clientIp, limitViewPoll, workerPollCache } from '#src/rate-limit.ts'
 import {
 	maybeBroadcastThreadView,
@@ -72,7 +73,7 @@ type ThreadListRow = ThreadRow & { member_count: number }
 export async function renderPage(
 	request: Request,
 	env: AppEnv,
-	user: UserRow | null,
+	user: SessionUser | UserRow | null,
 ) {
 	const url = new URL(request.url)
 	const baseUrl = appBaseUrl(env, request)
@@ -365,7 +366,7 @@ function adminJson(data: unknown, status = 200) {
 async function renderAdmin(
 	request: Request,
 	env: AppEnv,
-	user: UserRow | null,
+	user: SessionUser | UserRow | null,
 	asJson: boolean,
 ) {
 	if (!user) {
@@ -376,7 +377,7 @@ async function renderAdmin(
 		next.searchParams.set('next', adminPath)
 		return Response.redirect(next.toString(), 302)
 	}
-	if (!isOperatorLogin(user.login)) {
+	if (!userHasPermission(user, 'read:user:any')) {
 		return asJson
 			? adminJson({ ok: false, error: 'Not found.' }, 404)
 			: json({ ok: false, error: 'Not found.' }, 404)
@@ -400,7 +401,7 @@ async function renderAdmin(
 async function renderAccountPage(
 	request: Request,
 	env: AppEnv,
-	user: UserRow,
+	user: SessionUser | UserRow,
 	flash: ThreadFlash | null = null,
 ) {
 	const secret = env.COOKIE_SECRET?.trim() ?? 'dev'
@@ -422,7 +423,7 @@ async function renderAccountPage(
 async function accountPage(
 	env: AppEnv,
 	request: Request,
-	user: UserRow,
+	user: SessionUser | UserRow,
 	flash: ThreadFlash | null,
 ) {
 	const plan = getPlan(planOf(user))
@@ -527,7 +528,7 @@ async function accountPage(
 	}
 	${accountBillingHtml({ user, csrf, checkoutAvailable, link })}
 	${
-		isOperatorLogin(user.login)
+		userHasPermission(user, 'update:user:any')
 			? `<h2>Operator</h2>
 	${new URL(request.url).searchParams.get('granted') === '1' ? '<p class="card">Granted.</p>' : ''}
 	<form class="card" method="post" action="/account/grants">
@@ -644,7 +645,7 @@ function accountError(code: string | null) {
 export async function handleAccountAction(
 	request: Request,
 	env: AppEnv,
-	user: UserRow,
+	user: SessionUser | UserRow,
 ) {
 	const url = new URL(request.url)
 	const secret = env.COOKIE_SECRET?.trim()
@@ -719,7 +720,7 @@ export async function handleAccountAction(
 		})
 	}
 	if (url.pathname === '/account/grants') {
-		if (!isOperatorLogin(user.login)) {
+		if (!userHasPermission(user, 'update:user:any')) {
 			return new Response('Not found', { status: 404 })
 		}
 		const granted = await grantMaxToLogin(

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -40,6 +40,12 @@ import {
 } from '#src/example-thread.ts'
 import { researchPage } from '#src/research-page.ts'
 import { grantMaxToLogin } from '#src/grants.ts'
+import {
+	adminJsonPath,
+	adminPage,
+	adminPath,
+	loadAdminInsights,
+} from '#src/admin.ts'
 import { getPlan, isOperatorLogin } from '#src/limits.ts'
 import { clientIp, limitViewPoll, workerPollCache } from '#src/rate-limit.ts'
 import {
@@ -167,6 +173,9 @@ export async function renderPage(
 				return Response.redirect(`${baseUrl}/auth/github`, 302)
 			}
 			return renderAccountPage(request, env, user)
+		case adminPath:
+		case adminJsonPath:
+			return renderAdmin(request, env, user, url.pathname === adminJsonPath)
 		default:
 			return null
 	}
@@ -340,6 +349,51 @@ async function pollThreadView(
 		},
 		200,
 		{ 'retry-after': String(listed.retryAfter) },
+	)
+}
+
+function adminJson(data: unknown, status = 200) {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: {
+			'content-type': 'application/json; charset=utf-8',
+			'cache-control': 'no-store',
+		},
+	})
+}
+
+async function renderAdmin(
+	request: Request,
+	env: AppEnv,
+	user: UserRow | null,
+	asJson: boolean,
+) {
+	if (!user) {
+		if (asJson) {
+			return adminJson({ ok: false, error: 'Sign in required.' }, 401)
+		}
+		const next = new URL('/auth/github', appBaseUrl(env, request))
+		next.searchParams.set('next', adminPath)
+		return Response.redirect(next.toString(), 302)
+	}
+	if (!isOperatorLogin(user.login)) {
+		return asJson
+			? adminJson({ ok: false, error: 'Not found.' }, 404)
+			: json({ ok: false, error: 'Not found.' }, 404)
+	}
+	const insights = await loadAdminInsights(env.DB)
+	if (asJson) return adminJson({ ok: true, ...insights })
+	return html(
+		layout({
+			user,
+			env,
+			path: adminPath,
+			title: 'Usage',
+			description: 'Operator usage snapshot for kody.exchange.',
+			extraHead: '<meta name="robots" content="noindex" />',
+			mainClass: 'admin-page',
+			body: adminPage(insights),
+		}),
 	)
 }
 

--- a/src/permissions-db.ts
+++ b/src/permissions-db.ts
@@ -1,0 +1,99 @@
+import { all, run } from '#src/db.ts'
+import {
+	emptyAccess,
+	isBootstrapAdminLogin,
+	isPermissionString,
+	isRoleName,
+	type AccessUser,
+	type PermissionString,
+	type RoleName,
+} from '#src/permissions.ts'
+
+type PermissionRow = {
+	role_name: string
+	action: string | null
+	entity: string | null
+	access: string | null
+}
+
+export async function getUserRolesAndPermissions(
+	db: D1Database,
+	userId: string,
+): Promise<AccessUser> {
+	const rows = await all<PermissionRow>(
+		db,
+		`SELECT DISTINCT r.name AS role_name, p.action, p.entity, p.access
+		 FROM user_roles ur
+		 INNER JOIN roles r ON r.id = ur.role_id
+		 LEFT JOIN role_permissions rp ON rp.role_id = r.id
+		 LEFT JOIN permissions p ON p.id = rp.permission_id
+		 WHERE ur.user_id = ?`,
+		userId,
+	)
+	const roleSet = new Set<RoleName>()
+	const permissionSet = new Set<PermissionString>()
+	for (const row of rows) {
+		if (isRoleName(row.role_name)) roleSet.add(row.role_name)
+		if (row.action && row.entity && row.access) {
+			const permission = `${row.action}:${row.entity}:${row.access}`
+			if (isPermissionString(permission)) permissionSet.add(permission)
+		}
+	}
+	return {
+		roles: [...roleSet].toSorted(),
+		permissions: [...permissionSet].toSorted(),
+	}
+}
+
+export async function assignUserRole(input: {
+	db: D1Database
+	userId: string
+	roleName: RoleName
+}) {
+	const result = await run(
+		input.db,
+		`INSERT OR IGNORE INTO user_roles (user_id, role_id)
+		 SELECT ?, id FROM roles WHERE name = ?`,
+		input.userId,
+		input.roleName,
+	)
+	return { assigned: (result.meta?.changes ?? 0) > 0 }
+}
+
+export async function removeUserRole(input: {
+	db: D1Database
+	userId: string
+	roleName: RoleName
+}) {
+	await run(
+		input.db,
+		`DELETE FROM user_roles
+		 WHERE user_id = ?
+		   AND role_id = (SELECT id FROM roles WHERE name = ?)`,
+		input.userId,
+		input.roleName,
+	)
+}
+
+export async function ensureAccountRoles(
+	db: D1Database,
+	userId: string,
+	login: string,
+) {
+	await assignUserRole({ db, userId, roleName: 'user' })
+	if (isBootstrapAdminLogin(login)) {
+		await assignUserRole({ db, userId, roleName: 'admin' })
+	}
+	return getUserRolesAndPermissions(db, userId)
+}
+
+export async function loadAccessOrEmpty(
+	db: D1Database,
+	userId: string,
+): Promise<AccessUser> {
+	try {
+		return await getUserRolesAndPermissions(db, userId)
+	} catch {
+		return emptyAccess()
+	}
+}

--- a/src/permissions-db.ts
+++ b/src/permissions-db.ts
@@ -1,7 +1,6 @@
 import { all, run } from '#src/db.ts'
 import {
 	emptyAccess,
-	isBootstrapAdminLogin,
 	isPermissionString,
 	isRoleName,
 	type AccessUser,
@@ -75,15 +74,8 @@ export async function removeUserRole(input: {
 	)
 }
 
-export async function ensureAccountRoles(
-	db: D1Database,
-	userId: string,
-	login: string,
-) {
+export async function ensureAccountRoles(db: D1Database, userId: string) {
 	await assignUserRole({ db, userId, roleName: 'user' })
-	if (isBootstrapAdminLogin(login)) {
-		await assignUserRole({ db, userId, roleName: 'admin' })
-	}
 	return getUserRolesAndPermissions(db, userId)
 }
 

--- a/src/permissions.node.test.ts
+++ b/src/permissions.node.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import { handleRequest } from '#src/index.ts'
+import {
+	listAdminRolePermissionStrings,
+	listRegistryPermissionStrings,
+	listUserRolePermissionStrings,
+	userHasPermission,
+	userHasRole,
+} from '#src/permissions.ts'
+import {
+	assignUserRole,
+	ensureAccountRoles,
+	getUserRolesAndPermissions,
+	removeUserRole,
+} from '#src/permissions-db.ts'
+import {
+	createSignedInUser,
+	createTestEnv,
+	request,
+} from '#src/test-support.ts'
+
+test('permission registry matches the RBAC migration', () => {
+	const sql = readFileSync(
+		join(
+			dirname(fileURLToPath(import.meta.url)),
+			'../migrations/0007_rbac.sql',
+		),
+		'utf8',
+	)
+	const inserted = [
+		...sql.matchAll(
+			/'((?:create|read|update|delete))', '((?:user|role))', '((?:own|any))'/g,
+		),
+	].map((match) => `${match[1]}:${match[2]}:${match[3]}`)
+	expect(inserted.toSorted()).toEqual(
+		listRegistryPermissionStrings().toSorted(),
+	)
+	expect(
+		listUserRolePermissionStrings().every((item) => item.endsWith(':own')),
+	).toBe(true)
+	expect(listAdminRolePermissionStrings()).toEqual(
+		listRegistryPermissionStrings(),
+	)
+})
+
+test('signup assigns the user role and bootstraps admin for the first operator', async () => {
+	const env = createTestEnv()
+	const operator = await createSignedInUser(env, {
+		id: 'usr_op',
+		github_id: '99',
+		login: 'kentcdodds',
+	})
+	const member = await createSignedInUser(env, {
+		id: 'usr_member',
+		github_id: '8',
+		login: 'jane',
+	})
+
+	expect(operator.user.roles).toEqual(['admin', 'user'])
+	expect(userHasPermission(operator.user, 'read:user:any')).toBe(true)
+	expect(userHasPermission(operator.user, 'update:user:any')).toBe(true)
+	expect(member.user.roles).toEqual(['user'])
+	expect(userHasPermission(member.user, 'read:user:any')).toBe(false)
+	expect(userHasPermission(member.user, 'read:user:own')).toBe(true)
+	expect(userHasRole(member.user, 'admin')).toBe(false)
+})
+
+test('admin routes follow the role, not the GitHub login', async () => {
+	const env = createTestEnv()
+	const promoted = await createSignedInUser(env, {
+		id: 'usr_promoted',
+		github_id: '11',
+		login: 'sam',
+	})
+	await assignUserRole({
+		db: env.DB,
+		userId: promoted.user.id,
+		roleName: 'admin',
+	})
+	const demoted = await createSignedInUser(env, {
+		id: 'usr_demoted',
+		github_id: '99',
+		login: 'kentcdodds',
+	})
+	await removeUserRole({
+		db: env.DB,
+		userId: demoted.user.id,
+		roleName: 'admin',
+	})
+
+	const allowed = await handleRequest(
+		request('/admin', { headers: { cookie: promoted.cookie } }),
+		env,
+	)
+	expect(allowed.status).toBe(200)
+	expect(await allowed.text()).toContain('Usage')
+
+	const denied = await handleRequest(
+		request('/admin', { headers: { cookie: demoted.cookie } }),
+		env,
+	)
+	expect(denied.status).toBe(404)
+
+	const grantDenied = await handleRequest(
+		request('/account/grants', {
+			method: 'POST',
+			headers: {
+				cookie: demoted.cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf: demoted.csrf,
+				login: 'anyone',
+			}),
+		}),
+		env,
+	)
+	expect(grantDenied.status).toBe(404)
+})
+
+test('userHasPermission is explicit and fail-closed', () => {
+	expect(userHasPermission(null, 'read:user:any')).toBe(false)
+	expect(userHasPermission({ permissions: [] }, 'read:user:own')).toBe(false)
+	expect(
+		userHasPermission({ permissions: ['read:user:own'] }, 'read:user:own'),
+	).toBe(true)
+	expect(
+		userHasPermission({ permissions: ['read:user:own'] }, 'read:user:any'),
+	).toBe(false)
+})
+
+test('ensureAccountRoles is idempotent and unknown users fail closed', async () => {
+	const env = createTestEnv()
+	const created = await createSignedInUser(env, {
+		id: 'usr_once',
+		login: 'pat',
+	})
+	const again = await ensureAccountRoles(env.DB, created.user.id, 'pat')
+	expect(again.roles).toEqual(['user'])
+	const access = await getUserRolesAndPermissions(env.DB, created.user.id)
+	expect(access.roles).toEqual(['user'])
+	expect(await getUserRolesAndPermissions(env.DB, 'usr_missing')).toEqual({
+		roles: [],
+		permissions: [],
+	})
+})

--- a/src/permissions.node.test.ts
+++ b/src/permissions.node.test.ts
@@ -46,10 +46,10 @@ test('permission registry matches the RBAC migration', () => {
 	)
 })
 
-test('signup assigns the user role and bootstraps admin for the first operator', async () => {
+test('signup assigns the user role and never grants admin from login', async () => {
 	const env = createTestEnv()
-	const operator = await createSignedInUser(env, {
-		id: 'usr_op',
+	const firstAccount = await createSignedInUser(env, {
+		id: 'usr_first',
 		github_id: '99',
 		login: 'kentcdodds',
 	})
@@ -59,9 +59,9 @@ test('signup assigns the user role and bootstraps admin for the first operator',
 		login: 'jane',
 	})
 
-	expect(operator.user.roles).toEqual(['admin', 'user'])
-	expect(userHasPermission(operator.user, 'read:user:any')).toBe(true)
-	expect(userHasPermission(operator.user, 'update:user:any')).toBe(true)
+	expect(firstAccount.user.roles).toEqual(['user'])
+	expect(userHasPermission(firstAccount.user, 'read:user:any')).toBe(false)
+	expect(userHasPermission(firstAccount.user, 'read:user:own')).toBe(true)
 	expect(member.user.roles).toEqual(['user'])
 	expect(userHasPermission(member.user, 'read:user:any')).toBe(false)
 	expect(userHasPermission(member.user, 'read:user:own')).toBe(true)
@@ -138,7 +138,7 @@ test('ensureAccountRoles is idempotent and unknown users fail closed', async () 
 		id: 'usr_once',
 		login: 'pat',
 	})
-	const again = await ensureAccountRoles(env.DB, created.user.id, 'pat')
+	const again = await ensureAccountRoles(env.DB, created.user.id)
 	expect(again.roles).toEqual(['user'])
 	const access = await getUserRolesAndPermissions(env.DB, created.user.id)
 	expect(access.roles).toEqual(['user'])

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -20,12 +20,6 @@ export type AccessUser = {
 
 export type SessionUser = UserRow & AccessUser
 
-export const bootstrapAdminLogin = 'kentcdodds'
-
-export function isBootstrapAdminLogin(login: string) {
-	return login.toLowerCase() === bootstrapAdminLogin
-}
-
 export function isRoleName(value: string): value is RoleName {
 	return roleNames.includes(value as RoleName)
 }

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,100 @@
+import { type UserRow } from '#src/threads.ts'
+
+export const permissionActions = ['create', 'read', 'update', 'delete'] as const
+export const permissionEntities = ['user', 'role'] as const
+export const permissionAccesses = ['own', 'any'] as const
+export const roleNames = ['user', 'admin'] as const
+
+export type PermissionAction = (typeof permissionActions)[number]
+export type PermissionEntity = (typeof permissionEntities)[number]
+export type PermissionAccess = (typeof permissionAccesses)[number]
+export type RoleName = (typeof roleNames)[number]
+
+export type PermissionString =
+	`${PermissionAction}:${PermissionEntity}:${PermissionAccess}`
+
+export type AccessUser = {
+	roles: Array<RoleName>
+	permissions: Array<PermissionString>
+}
+
+export type SessionUser = UserRow & AccessUser
+
+export const bootstrapAdminLogin = 'kentcdodds'
+
+export function isBootstrapAdminLogin(login: string) {
+	return login.toLowerCase() === bootstrapAdminLogin
+}
+
+export function isRoleName(value: string): value is RoleName {
+	return roleNames.includes(value as RoleName)
+}
+
+export function isPermissionString(value: string): value is PermissionString {
+	const [action, entity, access] = value.split(':')
+	return (
+		permissionActions.includes(action as PermissionAction) &&
+		permissionEntities.includes(entity as PermissionEntity) &&
+		permissionAccesses.includes(access as PermissionAccess)
+	)
+}
+
+export function parsePermissionString(value: PermissionString) {
+	const [action, entity, access] = value.split(':') as [
+		PermissionAction,
+		PermissionEntity,
+		PermissionAccess,
+	]
+	return { action, entity, access }
+}
+
+export function buildPermissionString(input: {
+	action: PermissionAction
+	entity: PermissionEntity
+	access: PermissionAccess
+}): PermissionString {
+	return `${input.action}:${input.entity}:${input.access}`
+}
+
+export function listRegistryPermissionStrings(): Array<PermissionString> {
+	const permissions: Array<PermissionString> = []
+	for (const action of permissionActions) {
+		for (const entity of permissionEntities) {
+			for (const access of permissionAccesses) {
+				permissions.push(buildPermissionString({ action, entity, access }))
+			}
+		}
+	}
+	return permissions
+}
+
+export function listUserRolePermissionStrings(): Array<PermissionString> {
+	return listRegistryPermissionStrings().filter((permission) =>
+		permission.endsWith(':own'),
+	)
+}
+
+export function listAdminRolePermissionStrings(): Array<PermissionString> {
+	return listRegistryPermissionStrings()
+}
+
+export function userHasPermission(
+	user: object | null | undefined,
+	permission: PermissionString,
+) {
+	if (!user || !('permissions' in user) || !Array.isArray(user.permissions)) {
+		return false
+	}
+	return user.permissions.includes(permission)
+}
+
+export function userHasRole(user: object | null | undefined, role: RoleName) {
+	if (!user || !('roles' in user) || !Array.isArray(user.roles)) {
+		return false
+	}
+	return user.roles.includes(role)
+}
+
+export function emptyAccess(): AccessUser {
+	return { roles: [], permissions: [] }
+}

--- a/src/test-support.ts
+++ b/src/test-support.ts
@@ -6,6 +6,8 @@ import { csrfToken } from '#src/auth.ts'
 import { signPayload } from '#src/crypto.ts'
 import { run } from '#src/db.ts'
 import { type AppEnv } from '#src/env.ts'
+import { ensureAccountRoles } from '#src/permissions-db.ts'
+import { type SessionUser } from '#src/permissions.ts'
 import { type UserRow } from '#src/threads.ts'
 
 const migrationsDir = join(
@@ -178,6 +180,7 @@ export async function createSignedInUser(
 		user.stripe_subscription_id,
 		user.created_at,
 	)
+	const access = await ensureAccountRoles(env.DB, user.id, user.login)
 	const secret = env.COOKIE_SECRET ?? 'test-cookie-secret-at-least-32-bytes'
 	const session = await signPayload(
 		secret,
@@ -185,7 +188,7 @@ export async function createSignedInUser(
 	)
 	const csrf = await csrfToken(secret, user.id)
 	return {
-		user,
+		user: { ...user, ...access } satisfies SessionUser,
 		csrf,
 		cookie: `kx_session=${session}`,
 	}

--- a/src/test-support.ts
+++ b/src/test-support.ts
@@ -6,8 +6,12 @@ import { csrfToken } from '#src/auth.ts'
 import { signPayload } from '#src/crypto.ts'
 import { run } from '#src/db.ts'
 import { type AppEnv } from '#src/env.ts'
-import { ensureAccountRoles } from '#src/permissions-db.ts'
-import { type SessionUser } from '#src/permissions.ts'
+import {
+	assignUserRole,
+	ensureAccountRoles,
+	getUserRolesAndPermissions,
+} from '#src/permissions-db.ts'
+import { type RoleName, type SessionUser } from '#src/permissions.ts'
 import { type UserRow } from '#src/threads.ts'
 
 const migrationsDir = join(
@@ -150,8 +154,9 @@ export function request(path: string, init: RequestInit = {}) {
 
 export async function createSignedInUser(
 	env: AppEnv,
-	overrides: Partial<UserRow> = {},
+	overrides: Partial<UserRow> & { roles?: Array<RoleName> } = {},
 ) {
+	const { roles: extraRoles, ...userOverrides } = overrides
 	const user: UserRow = {
 		id: 'usr_1',
 		github_id: '1',
@@ -163,7 +168,7 @@ export async function createSignedInUser(
 		stripe_customer_id: null,
 		stripe_subscription_id: null,
 		created_at: 1,
-		...overrides,
+		...userOverrides,
 	}
 	await run(
 		env.DB,
@@ -180,7 +185,14 @@ export async function createSignedInUser(
 		user.stripe_subscription_id,
 		user.created_at,
 	)
-	const access = await ensureAccountRoles(env.DB, user.id, user.login)
+	let access = await ensureAccountRoles(env.DB, user.id)
+	for (const roleName of extraRoles ?? []) {
+		if (roleName === 'user') continue
+		await assignUserRole({ db: env.DB, userId: user.id, roleName })
+	}
+	if (extraRoles?.length) {
+		access = await getUserRolesAndPermissions(env.DB, user.id)
+	}
 	const secret = env.COOKIE_SECRET ?? 'test-cookie-secret-at-least-32-bytes'
 	const session = await signPayload(
 		secret,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
You said “build our back” and meant **RBAC**. This keeps the usage page from the first pass and replaces the hardcoded `kentcdodds` operator check with the Epic Stack / Kody model.

## RBAC

Same shape as Epic Stack and Kody:

- Users have roles
- Roles have permissions
- A user’s permissions are the union of their roles
- Permission strings are `action:entity:access` (`create|read|update|delete` × `user|role` × `own|any`)
- Checks are explicit: `userHasPermission(user, 'read:user:any')`
- Roles load fresh per request and fail closed (not stored in the session cookie)

Baseline roles (migration `0007_rbac.sql`):

- `user` — assigned at signup; all `:own` permissions
- `admin` — all `:own` plus all `:any`

There is no runtime path that grants `admin`. Assign it with SQL against `user_roles`. Signup never special-cases a GitHub login.

## What the permissions gate

- `/admin` and `/admin.json` require `read:user:any`
- Grant Max requires `update:user:any`
- Nav “Admin” follows the permission, not the login

A user who is not `kentcdodds` but holds `admin` can open `/admin`. `kentcdodds` without the admin role cannot.

## Usage page

After deploy, an admin can open `/admin` for counts and account/thread metadata. Message bodies, tokens, and guest IPs stay off that page.

`npm run validate` is green (95 tests).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a0b4ee4-27c2-48ba-b705-a71041110c68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a0b4ee4-27c2-48ba-b705-a71041110c68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin dashboard with usage statistics, recent activity, and daily message trends.
  - Added JSON access for administrative insights.
  - Introduced role-based permissions for account administration and access management.
  - Added an Admin navigation link for authorized users.

- **Security & Privacy**
  - Administrative access now requires explicit permissions.
  - Sensitive data, including message content, tokens, and guest IP addresses, is excluded from insights.
  - Unauthorized access is denied safely, and protected pages are excluded from search indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->