### PR TITLE
Keep threads forever and hard-delete with a 10s undo

### DIFF
--- a/docs/contributing/architecture/primitives.md
+++ b/docs/contributing/architecture/primitives.md
@@ -19,10 +19,11 @@ Stable nouns. Not a changelog.
 - Guest polls wait 5 seconds. Poll rate limits use Cache first and write KV at most every 30 seconds.
 - Shareable `/t/{kx_view_…}` cannot send from the browser. Guest copy prompt is always shown. Host copy prompt is only for the signed-in thread owner. View polls are IP-limited at 5 seconds. The watch page prefers a read-only WebSocket on `/live`; polling is the fallback. Guest `/v1` join/send/poll/webhook/blobs infer the thread from the token — no public thread id.
 - The host can archive a thread (`POST /v1/archive` as the first member, or owner `POST /api/threads/{id}/archive`). Archived threads stay readable until they expire, do not count as live, clear `webhook_url`, and reject send/poll/join with `409 thread_archived`. The watch page does not open `/live` or poll.
+- The owner can mark a thread to never expire (`POST /api/threads/{id}/keep`). Kept threads still count against the live thread limit until archived or deleted. Guest threads cannot be kept. The owner or host can hard-delete a thread (`POST /api/threads/{id}/delete` or `POST /v1/delete`); that cascade-deletes members, guest agents, and messages immediately.
 - Actions `OAUTH_GITHUB_*` map to Worker `GITHUB_*` (Actions reserves `GITHUB_*`).
 - Production Worker secrets are written only by `tools/ci/sync-worker-secrets.ts` during deploy. Do not `wrangler secret put` by hand.
 - `kody-exchange-blobs` is this product's R2 bucket. Do not use `kody-email-blobs` (that belongs to kody.codes email attachments).
-- Expired threads cascade-delete members, guest agents, and messages.
+- Expired threads cascade-delete members, guest agents, and messages. Threads with `never_expires_at` set are skipped by purge.
 - Authorization is RBAC: users have roles, roles have `action:entity:access` permissions, and a user's permissions are the union of their roles. The `user` role is `*:own`. The `admin` role is `*:own` plus `*:any`. Checks are explicit (`userHasPermission(user, 'read:user:any')`). Roles load fresh per request and fail closed.
 - There is no runtime path that grants `admin`. Assign it with SQL against `user_roles`.
 - `max` is granted by `update:user:any` (or a stored `plan_grants` row). Do not list it on public pricing, homepage, or agent docs. Stripe must not overwrite it.

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -13,7 +13,7 @@ Content-Type: application/json
 
 Ask the human for `purpose` and `name` before you POST — do not invent them. If they already gave you a real HTTPS webhook URL, you may also send `webhook_url`. Do not invent one. The response includes `connect_prompt` (follow it yourself; keep it secret), `join_prompt` (give the other person the exact text), and `view_url` (a read-only chat for humans), plus `token` and `join_token`. Guest `/v1` does not use a thread id. The join response `token` (`kx_live_…`) is the bearer for later requests — never send `join_token` as the bearer.
 
-Anyone with `view_url` can open `/t/{kx_view_…}` and watch the thread. Treat that link as an invite until the room is full — the page always shows the guest copy prompt, so a watcher can join an agent. The page stays live over a socket so new messages appear immediately (polling is the fallback), and it stays pinned to the latest message if you are already at the bottom. The page cannot send messages in the browser. The host copy prompt is only shown when the signed-in owner is looking at their own thread. The roster shows who has joined and whether a seat is still open. The host can archive the thread (`POST /v1/archive` or `POST /api/threads/{id}/archive`). After that the watch page no longer subscribes, and send or poll returns `409` with `code: thread_archived`.
+Anyone with `view_url` can open `/t/{kx_view_…}` and watch the thread. Treat that link as an invite until the room is full — the page always shows the guest copy prompt, so a watcher can join an agent. The page stays live over a socket so new messages appear immediately (polling is the fallback), and it stays pinned to the latest message if you are already at the bottom. The page cannot send messages in the browser. The host copy prompt is only shown when the signed-in owner is looking at their own thread. The roster shows who has joined and whether a seat is still open. The host can archive the thread (`POST /v1/archive` or `POST /api/threads/{id}/archive`). After that the watch page no longer subscribes, and send or poll returns `409` with `code: thread_archived`. The host can hard-delete with `POST /v1/delete`. An owner can keep a thread from expiring (`POST /api/threads/{id}/keep` — it still counts as live), restore retention (`POST /api/threads/{id}/expire`), or hard-delete (`POST /api/threads/{id}/delete`).
 
 ## Join / send / poll
 
@@ -36,6 +36,7 @@ Respect `Retry-After`. First poll `after=0`, then set `after` to the last messag
 - `webhook_url` on `POST /v1/threads` (or `create_thread`) if the human already gave you a real HTTPS URL
 - `PUT /v1/webhook` `{ "url": "https://…" }`
 - Host archive: `POST /v1/archive` (first member) — send and poll then return `409 thread_archived`
+- Host hard-delete: `POST /v1/delete` (first member) — cascade-deletes the room immediately
 - Pro blobs: `POST /v1/blobs` (raw body) → `{ blob: { id } }`
 
 ## OAuth and MCP
@@ -57,8 +58,11 @@ Authenticated user API (bearer access token):
 - `GET/POST /api/threads/{id}/messages`
 - `PUT /api/threads/{id}/webhook`
 - `POST /api/threads/{id}/archive`
+- `POST /api/threads/{id}/keep`
+- `POST /api/threads/{id}/expire`
+- `POST /api/threads/{id}/delete`
 
-`POST /mcp` is the same surface as JSON-RPC tools (`create_thread`, `list_threads`, `join_thread`, `send_message`, `list_messages`, `set_webhook`, `archive_thread`). Unauthenticated `/api` and `/mcp` calls return `401` with `WWW-Authenticate` plus a free-account `signup_url`. Guest create stays on `POST /v1/threads` with no token.
+`POST /mcp` is the same surface as JSON-RPC tools (`create_thread`, `list_threads`, `join_thread`, `send_message`, `list_messages`, `set_webhook`, `archive_thread`, `keep_thread`, `expire_thread`, `delete_thread`). Unauthenticated `/api` and `/mcp` calls return `401` with `WWW-Authenticate` plus a free-account `signup_url`. Guest create stays on `POST /v1/threads` with no token.
 
 ## Security research
 

--- a/migrations/0008_never_expires.sql
+++ b/migrations/0008_never_expires.sql
@@ -1,0 +1,1 @@
+ALTER TABLE threads ADD COLUMN never_expires_at INTEGER;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,6 +1,7 @@
 import { all, first } from '#src/db.ts'
 import { escapeHtml } from '#src/html.ts'
 import { accountPlan, yearMonth, type AccountPlanName } from '#src/limits.ts'
+import { sqlThreadLive, sqlThreadUnexpired } from '#src/threads.ts'
 
 export const adminPath = '/admin'
 export const adminJsonPath = '/admin.json'
@@ -27,7 +28,8 @@ export type AdminThreadInsight = {
 	guest: boolean
 	memberCount: number
 	createdAt: string
-	expiresAt: string
+	expiresAt: string | null
+	neverExpires: boolean
 	archived: boolean
 	lastMessageAt: string | null
 }
@@ -89,6 +91,7 @@ type ThreadRow = {
 	created_at: number
 	expires_at: number
 	archived_at: number | null
+	never_expires_at: number | null
 	member_count: number | string | null
 	last_message_at: number | string | null
 }
@@ -159,19 +162,19 @@ export async function loadAdminInsights(
 		count(
 			db,
 			`SELECT COUNT(*) AS n FROM threads
-			 WHERE owner_user_id IS NOT NULL AND expires_at > ? AND archived_at IS NULL`,
+			 WHERE owner_user_id IS NOT NULL AND ${sqlThreadLive()}`,
 			now,
 		),
 		count(
 			db,
 			`SELECT COUNT(*) AS n FROM threads
-			 WHERE owner_user_id IS NULL AND expires_at > ? AND archived_at IS NULL`,
+			 WHERE owner_user_id IS NULL AND ${sqlThreadLive()}`,
 			now,
 		),
 		count(
 			db,
 			`SELECT COUNT(*) AS n FROM threads
-			 WHERE expires_at > ? AND archived_at IS NOT NULL`,
+			 WHERE ${sqlThreadUnexpired()} AND archived_at IS NOT NULL`,
 			now,
 		),
 		count(db, 'SELECT COUNT(*) AS n FROM threads'),
@@ -195,8 +198,7 @@ export async function loadAdminInsights(
 			`SELECT COUNT(DISTINCT creator_ip) AS n FROM threads
 			 WHERE owner_user_id IS NULL
 			   AND creator_ip IS NOT NULL
-			   AND expires_at > ?
-			   AND archived_at IS NULL`,
+			   AND ${sqlThreadLive()}`,
 			now,
 		),
 		all<UserRow>(
@@ -204,7 +206,7 @@ export async function loadAdminInsights(
 			`SELECT u.login, u.name, u.email, u.plan, u.created_at,
 				 (
 					 SELECT COUNT(*) FROM threads t
-					 WHERE t.owner_user_id = u.id AND t.expires_at > ? AND t.archived_at IS NULL
+					 WHERE t.owner_user_id = u.id AND ${sqlThreadLive('t.')}
 				 ) AS live_threads,
 				 COALESCE((
 					 SELECT um.message_count FROM usage_months um
@@ -220,12 +222,12 @@ export async function loadAdminInsights(
 		all<ThreadRow>(
 			db,
 			`SELECT t.id, t.purpose, u.login AS owner_login, t.created_at, t.expires_at,
-				 t.archived_at,
+				 t.archived_at, t.never_expires_at,
 				 (SELECT COUNT(*) FROM thread_members m WHERE m.thread_id = t.id) AS member_count,
 				 (SELECT MAX(msg.created_at) FROM messages msg WHERE msg.thread_id = t.id) AS last_message_at
 			 FROM threads t
 			 LEFT JOIN users u ON u.id = t.owner_user_id
-			 WHERE t.expires_at > ?
+			 WHERE ${sqlThreadUnexpired('t.')}
 			 ORDER BY t.created_at DESC
 			 LIMIT ?`,
 			now,
@@ -291,7 +293,8 @@ export async function loadAdminInsights(
 			guest: row.owner_login == null,
 			memberCount: asCount(row.member_count),
 			createdAt: iso(row.created_at),
-			expiresAt: iso(row.expires_at),
+			expiresAt: row.never_expires_at != null ? null : iso(row.expires_at),
+			neverExpires: row.never_expires_at != null,
 			archived: row.archived_at != null,
 			lastMessageAt:
 				row.last_message_at == null ? null : iso(asCount(row.last_message_at)),

--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -440,6 +440,9 @@ test('pricing page explains live threads and participants', async () => {
 	expect(docsHtml).toContain('not a paid upgrade')
 	expect(docsHtml).toContain('new messages appear immediately')
 	expect(docsHtml).toContain('POST /v1/archive')
+	expect(docsHtml).toContain('POST /v1/delete')
+	expect(docsHtml).toContain('POST /api/threads/{id}/keep')
+	expect(docsHtml).toContain('POST /api/threads/{id}/delete')
 	expect(docsHtml).toContain(`href="${safetyPath}"`)
 	expect(docsHtml).not.toContain('Max')
 
@@ -593,4 +596,73 @@ test('host archive freezes send, poll, and the watch page live subscription', as
 		env,
 	)
 	expect(live.status).toBe(409)
+})
+
+test('host can hard-delete a guest thread and free the IP slot', async () => {
+	const env = createTestEnv()
+	const createdResponse = await handleRequest(
+		request('/v1/threads', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'cf-connecting-ip': '203.0.113.71',
+			},
+			body: JSON.stringify({ purpose: 'delete the room', name: 'host' }),
+		}),
+		env,
+	)
+	const created = (await createdResponse.json()) as {
+		ok: boolean
+		token: string
+		join_token: string
+		view_url: string
+	}
+	expect(created.ok).toBe(true)
+	const joined = await handleRequest(
+		request('/v1/join', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ join_token: created.join_token, name: 'guest' }),
+		}),
+		env,
+	)
+	const joinedBody = (await joined.json()) as { token: string }
+	const guestDelete = await handleRequest(
+		request('/v1/delete', {
+			method: 'POST',
+			headers: { authorization: `Bearer ${joinedBody.token}` },
+		}),
+		env,
+	)
+	expect(guestDelete.status).toBe(403)
+	const deleted = await handleRequest(
+		request('/v1/delete', {
+			method: 'POST',
+			headers: { authorization: `Bearer ${created.token}` },
+		}),
+		env,
+	)
+	expect(deleted.status).toBe(200)
+	const deletedBody = (await deleted.json()) as {
+		ok: boolean
+		deleted: boolean
+	}
+	expect(deletedBody.deleted).toBe(true)
+
+	const viewPath = new URL(created.view_url).pathname
+	const viewPage = await handleRequest(request(viewPath), env)
+	expect(viewPage.status).toBe(404)
+
+	const again = await handleRequest(
+		request('/v1/threads', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'cf-connecting-ip': '203.0.113.71',
+			},
+			body: JSON.stringify({ purpose: 'next room', name: 'host' }),
+		}),
+		env,
+	)
+	expect(again.status).toBe(200)
 })

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,7 @@ import {
 	archiveThreadAsHost,
 	assertThreadLive,
 	createThread,
+	deleteThreadAsHost,
 	maybeDispatchWebhook,
 	getAgentByToken,
 	joinThread,
@@ -153,6 +154,10 @@ export async function handleApi(
 
 	if (url.pathname === '/v1/archive' && request.method === 'POST') {
 		return archiveRoute(request, env, ctx)
+	}
+
+	if (url.pathname === '/v1/delete' && request.method === 'POST') {
+		return deleteRoute(request, env, ctx)
 	}
 
 	if (url.pathname === '/v1/blobs' && request.method === 'POST') {
@@ -429,6 +434,29 @@ async function archiveRoute(
 			...guestThreadJson(archived.thread),
 			archived: true,
 		},
+	})
+}
+
+async function deleteRoute(
+	request: Request,
+	env: AppEnv,
+	ctx?: ExecutionContext,
+) {
+	const auth = await requireAgent(request, env)
+	if (!auth.ok) return auth.response
+	const scoped = threadIdForAgent(auth.agent)
+	if (!scoped.ok) return scoped.response
+	const deleted = await deleteThreadAsHost({
+		db: env.DB,
+		threadId: scoped.threadId,
+		agent: auth.agent,
+	})
+	if (!deleted.ok) return errorResponse(deleted)
+	await maybeCloseThreadView(env, deleted.thread.id, ctx)
+	return json({
+		ok: true,
+		deleted: true,
+		thread: guestThreadJson(deleted.thread),
 	})
 }
 

--- a/src/html.ts
+++ b/src/html.ts
@@ -188,6 +188,10 @@ h3 { font-size: 1.15rem; margin: 0 0 .35rem; }
 pre, code { font-family: "IBM Plex Mono", monospace; }
 pre { overflow: auto; white-space: pre-wrap; background: var(--code-bg); color: var(--code-ink); padding: 1rem; border-radius: 0 12px 12px 0; font-size: .82rem; }
 .row { display: flex; gap: .6rem; flex-wrap: wrap; align-items: center; }
+.thread-actions form { margin: 0; }
+.thread-actions form p { margin: 0; }
+.card[data-pending-delete] { opacity: .6; }
+.card[data-pending-delete] .thread-actions form:not([data-delete-thread]) { display: none; }
 .jobs { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 1.6rem 0; }
 .jobs .card { margin: 0; }
 .jobs p { margin: 0; color: var(--muted); }
@@ -288,6 +292,58 @@ export function copyPromptScript() {
 	</script>`
 }
 
+export const deleteUndoSeconds = 10
+
+export function accountThreadActionsScript() {
+	return `<script>
+		document.querySelectorAll('[data-delete-thread]').forEach((form) => {
+			if (!(form instanceof HTMLFormElement)) return
+			const submit = form.querySelector('button[type="submit"]')
+			const undo = form.querySelector('[data-undo]')
+			const status = form.querySelector('[data-delete-status]')
+			const card = form.closest('.card')
+			let timer = 0
+			let left = ${deleteUndoSeconds}
+			function restore() {
+				window.clearInterval(timer)
+				timer = 0
+				left = ${deleteUndoSeconds}
+				if (submit instanceof HTMLElement) submit.hidden = false
+				if (undo instanceof HTMLElement) undo.hidden = true
+				if (status instanceof HTMLElement) {
+					status.hidden = true
+					status.textContent = ''
+				}
+				if (card instanceof HTMLElement) card.removeAttribute('data-pending-delete')
+			}
+			form.addEventListener('submit', (event) => {
+				if (form.getAttribute('data-confirmed') === '1') return
+				event.preventDefault()
+				if (submit instanceof HTMLElement) submit.hidden = true
+				if (undo instanceof HTMLElement) undo.hidden = false
+				if (status instanceof HTMLElement) {
+					status.hidden = false
+					status.textContent = 'Deleting in ' + left + 's'
+				}
+				if (card instanceof HTMLElement) card.setAttribute('data-pending-delete', '')
+				timer = window.setInterval(() => {
+					left -= 1
+					if (left <= 0) {
+						window.clearInterval(timer)
+						form.setAttribute('data-confirmed', '1')
+						form.submit()
+						return
+					}
+					if (status instanceof HTMLElement) status.textContent = 'Deleting in ' + left + 's'
+				}, 1000)
+			})
+			undo?.addEventListener('click', () => {
+				restore()
+			})
+		})
+	</script>`
+}
+
 function bubbleAccentStyle(kind: MessageKind, accentIndex: number) {
 	switch (kind) {
 		case 'system':
@@ -366,6 +422,7 @@ export function rosterLine(input: {
 export function threadViewPage(input: {
 	thread: Pick<ThreadRow, 'purpose' | 'expires_at'> & {
 		archived_at?: number | null
+		never_expires_at?: number | null
 	}
 	messages: Array<MessageEnvelope>
 	members: Array<{ id: string; name: string }>
@@ -384,7 +441,10 @@ export function threadViewPage(input: {
 	const lastId = input.messages.at(-1)?.id ?? '0'
 	const archived = isThreadArchived(input.thread)
 	const live = input.live !== false && !archived
-	const expiresAt = input.neverExpires ? null : input.thread.expires_at
+	const expiresAt =
+		input.neverExpires || input.thread.never_expires_at != null
+			? null
+			: input.thread.expires_at
 	const expiresAttr = expiresAt === null ? 'infinite' : String(expiresAt)
 	const stamp = input.stamp ?? (archived ? 'Archived' : 'Read-only')
 	const intro =
@@ -565,7 +625,7 @@ Content-Type: application/json
 Authorization: Bearer kx_live_…</pre>
 	<p>Introduce yourself once, then poll quietly until a peer writes. Reply to a new batch as one message. Do not invent a wrap-up timer. Guest rooms share a 50-message monthly cap. Joins post a system line so the other agent can see someone arrived.</p>
 	<p>Optional webhook: <code>webhook_url</code> on create, or <code>PUT /v1/webhook</code> with <code>{"url":"https://…"}</code>.</p>
-	<p>The host can close a live thread with <code>POST /v1/archive</code> (bearer of the first member) or, for an owned thread, <code>POST /api/threads/{id}/archive</code>. Archived threads stay readable until they expire, but they no longer count as live.</p>
+	<p>The host can close a live thread with <code>POST /v1/archive</code> (bearer of the first member) or, for an owned thread, <code>POST /api/threads/{id}/archive</code>. Archived threads stay readable until they expire, but they no longer count as live. The host can hard-delete with <code>POST /v1/delete</code>. An owner can keep a thread from expiring with <code>POST /api/threads/{id}/keep</code> (still counts as live), restore retention with <code>POST /api/threads/{id}/expire</code>, or hard-delete with <code>POST /api/threads/{id}/delete</code>.</p>
 	<h2>OAuth / MCP</h2>
 	<p>Included with a free GitHub account — not a paid upgrade. Guest create stays on <code>POST /v1/threads</code>. Sign in, then use <code>/api/</code> or point an MCP client at <code>/mcp</code>. Discovery is at <code>/.well-known/oauth-authorization-server</code>.</p>
 	<h2>Security research</h2>
@@ -590,7 +650,7 @@ export function privacyPage() {
 		<li>We do not sell your data.</li>
 	</ul>
 	<h2>Retention</h2>
-	<p>Guest threads are deleted after 24 hours. Free account data is kept 14 days of activity, Pro 90 days. Expired threads, members, and messages are purged. To delete an account, email <a href="mailto:support@kody.exchange">support@kody.exchange</a>.</p>
+	<p>Guest threads are deleted after 24 hours. Free account data is kept 14 days of activity, Pro 90 days. You can mark an owned thread so it never expires — it still counts against your live thread limit. You can also hard-delete a thread immediately. Expired threads, members, and messages are purged. To delete an account, email <a href="mailto:support@kody.exchange">support@kody.exchange</a>.</p>
 	<h2>Security research</h2>
 	<p>We published a closed-loop study of peer-channel exfil and what a watch link grants: <a href="${safetyPath}">Peer-channel security and privacy</a>.</p>
 	<h2>Processors</h2>

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,8 @@ export async function handleRequest(
 			purpose: card.thread.purpose,
 			members: card.members,
 			seats: card.seats,
-			expiresAt: card.thread.expires_at,
+			expiresAt:
+				card.thread.never_expires_at != null ? null : card.thread.expires_at,
 			archived: card.thread.archived_at != null,
 		})
 	}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -93,6 +93,42 @@ const tools = [
 			required: ['thread_id'],
 		},
 	},
+	{
+		name: 'keep_thread',
+		description:
+			'Mark a thread you own so it never expires. It still counts against your live thread limit until you archive or delete it.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				thread_id: { type: 'string' },
+			},
+			required: ['thread_id'],
+		},
+	},
+	{
+		name: 'expire_thread',
+		description:
+			'Restore normal retention on a thread you own that was marked to never expire.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				thread_id: { type: 'string' },
+			},
+			required: ['thread_id'],
+		},
+	},
+	{
+		name: 'delete_thread',
+		description:
+			'Hard-delete a thread you own. Members, messages, and guest agents are removed immediately. This cannot be undone.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				thread_id: { type: 'string' },
+			},
+			required: ['thread_id'],
+		},
+	},
 ] as const
 
 function rpcResult(id: JsonRpc['id'], result: unknown) {
@@ -270,6 +306,36 @@ async function callTool(
 		case 'archive_thread':
 			response = await handleUserApi(
 				new Request(new URL(`/api/threads/${threadId}/archive`, request.url), {
+					method: 'POST',
+				}),
+				env,
+				user,
+				ctx,
+			)
+			break
+		case 'keep_thread':
+			response = await handleUserApi(
+				new Request(new URL(`/api/threads/${threadId}/keep`, request.url), {
+					method: 'POST',
+				}),
+				env,
+				user,
+				ctx,
+			)
+			break
+		case 'expire_thread':
+			response = await handleUserApi(
+				new Request(new URL(`/api/threads/${threadId}/expire`, request.url), {
+					method: 'POST',
+				}),
+				env,
+				user,
+				ctx,
+			)
+			break
+		case 'delete_thread':
+			response = await handleUserApi(
+				new Request(new URL(`/api/threads/${threadId}/delete`, request.url), {
 					method: 'POST',
 				}),
 				env,

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -320,3 +320,113 @@ test('OAuth user API creates, lists, sends, and sets a webhook', async () => {
 	expect(mcpPayload.ok).toBe(true)
 	expect(mcpPayload.thread.archived).toBe(true)
 })
+
+test('OAuth user API can keep and hard-delete a thread', async () => {
+	const env = createTestEnv()
+	const owner = await createSignedInUser(env)
+	env.OAUTH_USER = owner.user
+
+	const created = await handleRequest(
+		request('/api/threads', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ purpose: 'keep forever', name: 'host' }),
+		}),
+		env,
+	)
+	const createdBody = (await created.json()) as {
+		ok: boolean
+		thread: { id: string; never_expires: boolean; expires_at: string | null }
+	}
+	expect(createdBody.thread.never_expires).toBe(false)
+	expect(createdBody.thread.expires_at).toBeTruthy()
+
+	const kept = await handleRequest(
+		request(`/api/threads/${createdBody.thread.id}/keep`, {
+			method: 'POST',
+		}),
+		env,
+	)
+	expect(kept.status).toBe(200)
+	const keptBody = (await kept.json()) as {
+		ok: boolean
+		thread: { never_expires: boolean; expires_at: string | null }
+	}
+	expect(keptBody.thread.never_expires).toBe(true)
+	expect(keptBody.thread.expires_at).toBeNull()
+
+	const listed = await handleRequest(request('/api/threads'), env)
+	const listedBody = (await listed.json()) as {
+		threads: Array<{ id: string; never_expires: boolean }>
+	}
+	expect(
+		listedBody.threads.find((thread) => thread.id === createdBody.thread.id)
+			?.never_expires,
+	).toBe(true)
+
+	const mcpKeep = await handleRequest(
+		request('/mcp', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 3,
+				method: 'tools/call',
+				params: {
+					name: 'keep_thread',
+					arguments: { thread_id: createdBody.thread.id },
+				},
+			}),
+		}),
+		env,
+	)
+	expect(mcpKeep.status).toBe(200)
+
+	const deleted = await handleRequest(
+		request(`/api/threads/${createdBody.thread.id}/delete`, {
+			method: 'POST',
+		}),
+		env,
+	)
+	expect(deleted.status).toBe(200)
+	const deletedBody = (await deleted.json()) as {
+		ok: boolean
+		deleted: boolean
+	}
+	expect(deletedBody.deleted).toBe(true)
+
+	const listedAfter = await handleRequest(request('/api/threads'), env)
+	const listedAfterBody = (await listedAfter.json()) as {
+		threads: Array<{ id: string }>
+	}
+	expect(listedAfterBody.threads.map((thread) => thread.id)).not.toContain(
+		createdBody.thread.id,
+	)
+
+	const mcpDelete = await handleRequest(
+		request('/mcp', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 4,
+				method: 'tools/call',
+				params: {
+					name: 'delete_thread',
+					arguments: { thread_id: createdBody.thread.id },
+				},
+			}),
+		}),
+		env,
+	)
+	expect(mcpDelete.status).toBe(200)
+	const mcpRpc = (await mcpDelete.json()) as {
+		result: { content: Array<{ text: string }> }
+	}
+	const mcpPayload = JSON.parse(mcpRpc.result.content[0]?.text ?? '{}') as {
+		ok: boolean
+		code?: string
+	}
+	expect(mcpPayload.ok).toBe(false)
+	expect(mcpPayload.code).toBe('not_found')
+})

--- a/src/og-pages.node.test.ts
+++ b/src/og-pages.node.test.ts
@@ -84,4 +84,11 @@ test('view OG paths and copy stay on the public roster, not tokens', () => {
 			archived: true,
 		}),
 	).toBe('1 of 2 · harbor · archived')
+	expect(
+		viewOgLede({
+			members: [{ name: 'harbor' }, { name: 'relay' }],
+			seats: 2,
+			expiresAt: null,
+		}),
+	).toBe('2 of 2 · harbor, relay · infinite retention')
 })

--- a/src/og-pages.ts
+++ b/src/og-pages.ts
@@ -141,7 +141,7 @@ export function viewOgTitle(purpose: string | null) {
 export type ViewOgRoster = {
 	members: Array<{ name: string }>
 	seats: number
-	expiresAt: number
+	expiresAt: number | null
 	archived?: boolean
 }
 
@@ -153,8 +153,10 @@ export function viewOgStamp(archived?: boolean) {
 	return archived ? 'Archived' : 'Read-only'
 }
 
-export function viewOgRetention(expiresAt: number) {
-	return `expires ${new Date(expiresAt).toISOString().slice(0, 10)}`
+export function viewOgRetention(expiresAt: number | null) {
+	return expiresAt === null
+		? 'infinite retention'
+		: `expires ${new Date(expiresAt).toISOString().slice(0, 10)}`
 }
 
 export function viewOgLede(input: ViewOgRoster) {

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -448,3 +448,86 @@ test('signed-in host can close a thread from the account page', async () => {
 	)
 	expect(await expiredPage.text()).toContain('That thread was not found.')
 })
+
+test('signed-in host can keep and hard-delete a thread from the account page', async () => {
+	const env = createTestEnv()
+	const { cookie, csrf } = await createSignedInUser(env)
+	const created = await handleRequest(
+		request('/account/threads', {
+			method: 'POST',
+			headers: {
+				cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf,
+				purpose: 'keep then delete',
+				name: 'host-agent',
+			}),
+		}),
+		env,
+	)
+	expect(created.status).toBe(303)
+	const flash = firstSetCookie(created)
+	const withPrompts = await handleRequest(
+		request('/account', { headers: { cookie: `${cookie}; ${flash}` } }),
+		env,
+	)
+	const accountHtml = await withPrompts.text()
+	expect(accountHtml).toContain('Keep forever')
+	expect(accountHtml).toContain('Delete thread')
+	expect(accountHtml).toContain('data-delete-thread')
+	expect(accountHtml).toContain('Deleting in ')
+	expect(accountHtml).toContain('left = 10')
+	const threadId = /th_[a-z0-9]+/.exec(accountHtml)?.[0]
+	expect(threadId).toBeTruthy()
+
+	const kept = await handleRequest(
+		request(`/account/threads/${threadId}/keep`, {
+			method: 'POST',
+			headers: {
+				cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({ csrf }),
+		}),
+		env,
+	)
+	expect(kept.status).toBe(303)
+	expect(kept.headers.get('location')).toBe(
+		'https://kody.exchange/account?kept=1',
+	)
+	const keptPage = await handleRequest(
+		request('/account?kept=1', { headers: { cookie } }),
+		env,
+	)
+	const keptHtml = await keptPage.text()
+	expect(keptHtml).toContain('This thread will not expire.')
+	expect(keptHtml).toContain('never expires')
+	expect(keptHtml).toContain('Allow to expire')
+	expect(keptHtml).toContain('still counts as a live thread')
+
+	const deleted = await handleRequest(
+		request(`/account/threads/${threadId}/delete`, {
+			method: 'POST',
+			headers: {
+				cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({ csrf }),
+		}),
+		env,
+	)
+	expect(deleted.status).toBe(303)
+	expect(deleted.headers.get('location')).toBe(
+		'https://kody.exchange/account?deleted=1',
+	)
+	const later = await handleRequest(
+		request('/account?deleted=1', { headers: { cookie } }),
+		env,
+	)
+	const laterHtml = await later.text()
+	expect(laterHtml).toContain('Thread deleted.')
+	expect(laterHtml).not.toContain('keep then delete')
+	expect(laterHtml).toContain("What's this thread for?")
+})

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -16,6 +16,7 @@ import {
 import { all, first } from '#src/db.ts'
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
 import {
+	accountThreadActionsScript,
 	copyPromptScript,
 	docsPage,
 	escapeHtml,
@@ -57,10 +58,15 @@ import {
 	archiveThread,
 	countOwnedThreads,
 	createThread,
+	deleteThread,
 	getHostAgent,
 	isThreadArchived,
+	isThreadNeverExpiring,
 	listMessagesForView,
 	listThreadMembers,
+	setThreadNeverExpires,
+	sqlThreadLive,
+	sqlThreadUnexpired,
 	threadArchivedViewError,
 	threadViewPrompts,
 	threadViewUrlFor,
@@ -229,7 +235,9 @@ async function renderThreadView(
 				purpose: listed.thread.purpose,
 				members: listed.members,
 				seats: listed.seats,
-				expiresAt: listed.thread.expires_at,
+				expiresAt: isThreadNeverExpiring(listed.thread)
+					? null
+					: listed.thread.expires_at,
 				archived: listed.thread.archived_at != null,
 			}),
 			extraHead:
@@ -245,6 +253,7 @@ async function renderThreadView(
 				guestPrompt: prompts.guestPrompt,
 				hostAgentId: host?.id ?? null,
 				viewer: ownsThread ? 'host' : 'guest',
+				neverExpires: isThreadNeverExpiring(listed.thread),
 			}),
 		}),
 	)
@@ -436,7 +445,7 @@ async function accountPage(
 			 SELECT COUNT(*) FROM thread_members m WHERE m.thread_id = t.id
 		 ) AS member_count
 		 FROM threads t
-		 WHERE t.owner_user_id = ? AND t.expires_at > ? AND t.archived_at IS NULL
+		 WHERE t.owner_user_id = ? AND ${sqlThreadLive('t.')}
 		 ORDER BY t.created_at DESC`,
 		user.id,
 		now,
@@ -447,7 +456,7 @@ async function accountPage(
 			 SELECT COUNT(*) FROM thread_members m WHERE m.thread_id = t.id
 		 ) AS member_count
 		 FROM threads t
-		 WHERE t.owner_user_id = ? AND t.expires_at > ? AND t.archived_at IS NOT NULL
+		 WHERE t.owner_user_id = ? AND ${sqlThreadUnexpired('t.')} AND t.archived_at IS NOT NULL
 		 ORDER BY t.archived_at DESC`,
 		user.id,
 		now,
@@ -457,6 +466,9 @@ async function accountPage(
 	const upgraded = new URL(request.url).searchParams.get('upgraded') === '1'
 	const archivedFlash =
 		new URL(request.url).searchParams.get('archived') === '1'
+	const keptFlash = new URL(request.url).searchParams.get('kept') === '1'
+	const expireFlash = new URL(request.url).searchParams.get('expire') === '1'
+	const deletedFlash = new URL(request.url).searchParams.get('deleted') === '1'
 	const error = accountError(new URL(request.url).searchParams.get('error'))
 	const checkoutAvailable = Boolean(
 		stripeSecretConfigured(env) && env.STRIPE_PRO_PRICE_ID,
@@ -470,13 +482,16 @@ async function accountPage(
 	<p class="tiny">OAuth API and MCP are included with a signed-in account. Point integrations at <code>${escapeHtml(appBaseUrl(env, request))}/mcp</code> and approve the prompt. Guest threads still work over plain <code>/v1</code> with no account.</p>
 	${upgraded ? `<p class="card">Pro is active. Thank you.</p>` : ''}
 	${archivedFlash ? `<p class="card">Thread archived. It is read-only now.</p>` : ''}
+	${keptFlash ? `<p class="card">This thread will not expire. It still counts as a live thread.</p>` : ''}
+	${expireFlash ? `<p class="card">This thread will expire on the usual retention clock.</p>` : ''}
+	${deletedFlash ? `<p class="card">Thread deleted.</p>` : ''}
 	${error ? `<p class="card">${escapeHtml(error)}</p>` : ''}
 	${flash ? threadFlashHtml(flash) : ''}
 	${
 		flash
 			? ''
 			: atThreadLimit
-				? `<p class="card">You're at your live thread limit. Close one, or wait for one to expire${plan.name === 'free' ? ', or upgrade to Pro' : ''}.</p>`
+				? `<p class="card">You're at your live thread limit. Close or delete one, or wait for one to expire${plan.name === 'free' ? ', or upgrade to Pro' : ''}.</p>`
 				: `<form class="card" method="post" action="/account/threads">
 		<input type="hidden" name="csrf" value="${escapeHtml(csrf)}" />
 		<p>After you create the thread:</p>
@@ -521,6 +536,7 @@ async function accountPage(
 					thread,
 					baseUrl: appBaseUrl(env, request),
 					seats: plan.liveAgents,
+					csrf,
 				}),
 			),
 		)
@@ -540,6 +556,7 @@ async function accountPage(
 			: ''
 	}
 	${copyPromptScript()}
+	${accountThreadActionsScript()}
 	`
 }
 
@@ -579,17 +596,43 @@ async function threadListItem(input: {
 	const memberLabel = `${members} of ${input.seats}`
 	const href = await threadViewUrlFor(input.baseUrl, input.thread)
 	const archived = isThreadArchived(input.thread)
-	const close = input.csrf
-		? `<form method="post" action="/account/threads/${escapeHtml(input.thread.id)}/archive">
-		<input type="hidden" name="csrf" value="${escapeHtml(input.csrf)}" />
-		<p><button type="submit">Close thread</button></p>
-	</form>`
+	const neverExpires = isThreadNeverExpiring(input.thread)
+	const retention = archived
+		? neverExpires
+			? 'archived · never expires'
+			: 'archived'
+		: neverExpires
+			? 'never expires'
+			: `expires ${new Date(input.thread.expires_at).toISOString()}`
+	const actions = input.csrf
+		? `<div class="row thread-actions">
+		<form method="post" action="/account/threads/${escapeHtml(input.thread.id)}/${neverExpires ? 'expire' : 'keep'}">
+			<input type="hidden" name="csrf" value="${escapeHtml(input.csrf)}" />
+			<p><button type="submit">${neverExpires ? 'Allow to expire' : 'Keep forever'}</button></p>
+		</form>
+		${
+			archived
+				? ''
+				: `<form method="post" action="/account/threads/${escapeHtml(input.thread.id)}/archive">
+			<input type="hidden" name="csrf" value="${escapeHtml(input.csrf)}" />
+			<p><button type="submit">Close thread</button></p>
+		</form>`
+		}
+		<form method="post" action="/account/threads/${escapeHtml(input.thread.id)}/delete" data-delete-thread>
+			<input type="hidden" name="csrf" value="${escapeHtml(input.csrf)}" />
+			<p>
+				<button type="submit">Delete thread</button>
+				<button type="button" data-undo hidden>Undo</button>
+				<span class="tiny" data-delete-status hidden></span>
+			</p>
+		</form>
+	</div>`
 		: ''
 	return `<article class="card">
 		<h3><a href="${escapeHtml(href)}">${escapeHtml(purpose)}</a></h3>
-		<p class="tiny"><code>${escapeHtml(input.thread.id)}</code> · ${escapeHtml(memberLabel)} · ${archived ? 'archived' : `expires ${escapeHtml(new Date(input.thread.expires_at).toISOString())}`}</p>
+		<p class="tiny"><code>${escapeHtml(input.thread.id)}</code> · ${escapeHtml(memberLabel)} · ${escapeHtml(retention)}</p>
 		<p><a href="${escapeHtml(href)}">Open read-only chat</a></p>
-		${close}
+		${actions}
 	</article>`
 }
 
@@ -635,6 +678,12 @@ function accountError(code: string | null) {
 			return 'That thread was not found.'
 		case 'archive_failed':
 			return 'Could not archive that thread. Try again.'
+		case 'keep_failed':
+			return 'Could not update that thread. Try again.'
+		case 'keep_forbidden':
+			return 'Guest threads cannot be kept forever.'
+		case 'delete_failed':
+			return 'Could not delete that thread. Try again.'
 		case 'bad_login':
 			return 'That GitHub login is not valid.'
 		default:
@@ -656,14 +705,16 @@ export async function handleAccountAction(
 		return new Response('Bad CSRF token', { status: 403 })
 	}
 
-	const archivePath = url.pathname.match(
-		/^\/account\/threads\/([^/]+)\/archive$/,
+	const threadAction = url.pathname.match(
+		/^\/account\/threads\/([^/]+)\/(archive|keep|expire|delete)$/,
 	)
-	if (archivePath?.[1]) {
+	if (threadAction?.[1] && threadAction[2]) {
+		const action = threadAccountAction(threadAction[2])
+		if (!action) return new Response('Not found', { status: 404 })
 		const owned = await first<ThreadRow>(
 			env.DB,
 			'SELECT * FROM threads WHERE id = ? AND owner_user_id = ?',
-			archivePath[1],
+			threadAction[1],
 			user.id,
 		)
 		if (!owned) {
@@ -671,19 +722,58 @@ export async function handleAccountAction(
 			next.searchParams.set('error', 'not_found')
 			return Response.redirect(next.toString(), 303)
 		}
-		const archived = await archiveThread({
-			db: env.DB,
-			threadId: owned.id,
-		})
-		if (!archived.ok) {
-			const next = new URL('/account', appBaseUrl(env, request))
-			next.searchParams.set('error', archived.code)
-			return Response.redirect(next.toString(), 303)
+		switch (action) {
+			case 'archive': {
+				const archived = await archiveThread({
+					db: env.DB,
+					threadId: owned.id,
+				})
+				if (!archived.ok) {
+					const next = new URL('/account', appBaseUrl(env, request))
+					next.searchParams.set('error', archived.code)
+					return Response.redirect(next.toString(), 303)
+				}
+				await maybeCloseThreadView(env, archived.thread.id)
+				const next = new URL('/account', appBaseUrl(env, request))
+				next.searchParams.set('archived', '1')
+				return Response.redirect(next.toString(), 303)
+			}
+			case 'keep':
+			case 'expire': {
+				const updated = await setThreadNeverExpires({
+					db: env.DB,
+					threadId: owned.id,
+					neverExpires: action === 'keep',
+				})
+				if (!updated.ok) {
+					const next = new URL('/account', appBaseUrl(env, request))
+					next.searchParams.set('error', updated.code)
+					return Response.redirect(next.toString(), 303)
+				}
+				const next = new URL('/account', appBaseUrl(env, request))
+				next.searchParams.set(action === 'keep' ? 'kept' : 'expire', '1')
+				return Response.redirect(next.toString(), 303)
+			}
+			case 'delete': {
+				const deleted = await deleteThread({
+					db: env.DB,
+					threadId: owned.id,
+				})
+				if (!deleted.ok) {
+					const next = new URL('/account', appBaseUrl(env, request))
+					next.searchParams.set('error', deleted.code)
+					return Response.redirect(next.toString(), 303)
+				}
+				await maybeCloseThreadView(env, deleted.thread.id)
+				const next = new URL('/account', appBaseUrl(env, request))
+				next.searchParams.set('deleted', '1')
+				return Response.redirect(next.toString(), 303)
+			}
+			default: {
+				const exhaustive: never = action
+				return exhaustive
+			}
 		}
-		await maybeCloseThreadView(env, archived.thread.id)
-		const next = new URL('/account', appBaseUrl(env, request))
-		next.searchParams.set('archived', '1')
-		return Response.redirect(next.toString(), 303)
 	}
 	if (url.pathname === '/account/threads') {
 		const created = await createThread({
@@ -749,6 +839,18 @@ export async function handleAccountAction(
 	}
 
 	return new Response('Not found', { status: 404 })
+}
+
+function threadAccountAction(value: string) {
+	switch (value) {
+		case 'archive':
+		case 'keep':
+		case 'expire':
+		case 'delete':
+			return value
+		default:
+			return null
+	}
 }
 
 function html(body: string, status = 200, extra?: HeadersInit) {

--- a/src/threads.node.test.ts
+++ b/src/threads.node.test.ts
@@ -3,8 +3,11 @@ import { createTestEnv } from '#src/test-support.ts'
 import {
 	archiveThread,
 	archiveThreadAsHost,
+	countOwnedThreads,
 	createAccountAgent,
 	createThread,
+	deleteThread,
+	deleteThreadAsHost,
 	getAgentByToken,
 	joinThread,
 	joinTokenFor,
@@ -13,7 +16,9 @@ import {
 	listThreadMembers,
 	liveTokenFor,
 	maybeDispatchWebhook,
+	purgeExpired,
 	sendMessage,
+	setThreadNeverExpires,
 	setWebhook,
 	viewTokenFor,
 } from '#src/threads.ts'
@@ -544,4 +549,195 @@ test('webhook dispatch stays alive through waitUntil', async () => {
 	} finally {
 		globalThis.fetch = originalFetch
 	}
+})
+
+test('owner can keep a thread forever; it still counts as live and survives purge', async () => {
+	const env = createTestEnv()
+	const now = Date.parse('2026-08-17T00:00:00Z')
+	await run(
+		env.DB,
+		`INSERT INTO users (id, github_id, login, name, avatar_url, email, plan, stripe_customer_id, stripe_subscription_id, created_at)
+		 VALUES (?, ?, ?, ?, NULL, NULL, 'free', NULL, NULL, ?)`,
+		'usr_keep',
+		'42',
+		'keeper',
+		'Keeper',
+		now,
+	)
+	const first = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: 'usr_keep',
+		purpose: 'keep me',
+		name: 'host',
+		now,
+	})
+	if (!first.ok) throw new Error(first.error)
+	const kept = await setThreadNeverExpires({
+		db: env.DB,
+		threadId: first.thread.id,
+		neverExpires: true,
+		now: now + 1000,
+	})
+	expect(kept.ok).toBe(true)
+	if (!kept.ok) throw new Error(kept.error)
+	expect(kept.thread.never_expires_at).toBe(now + 1000)
+	expect(kept.thread.expires_at).toBe(first.thread.expires_at)
+
+	const sent = await sendMessage({
+		db: env.DB,
+		threadId: first.thread.id,
+		agent: first.agent,
+		body: { text: 'still here' },
+		now: now + 2000,
+	})
+	if (!sent.ok) throw new Error(sent.error)
+	const afterSend = await setThreadNeverExpires({
+		db: env.DB,
+		threadId: first.thread.id,
+		neverExpires: true,
+		now: now + 3000,
+	})
+	if (!afterSend.ok) throw new Error(afterSend.error)
+	expect(afterSend.thread.expires_at).toBe(first.thread.expires_at)
+	expect(afterSend.thread.never_expires_at).toBe(now + 1000)
+
+	await run(
+		env.DB,
+		'UPDATE threads SET expires_at = ? WHERE id = ?',
+		now - 1,
+		first.thread.id,
+	)
+	expect(await purgeExpired(env.DB, now + 4000)).toBe(0)
+	const viewed = await listMessagesForView({
+		db: env.DB,
+		viewToken: await viewTokenFor(first.thread),
+		now: now + 4000,
+	})
+	if (!viewed.ok) throw new Error(viewed.error)
+	expect(viewed.thread.never_expires_at).toBe(now + 1000)
+
+	const second = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: 'usr_keep',
+		purpose: 'two',
+		name: 'host',
+		now: now + 5000,
+	})
+	if (!second.ok) throw new Error(second.error)
+	const third = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: 'usr_keep',
+		purpose: 'three',
+		name: 'host',
+		now: now + 6000,
+	})
+	if (!third.ok) throw new Error(third.error)
+	expect(await countOwnedThreads(env.DB, 'usr_keep')).toBe(3)
+	const fourth = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: 'usr_keep',
+		purpose: 'four',
+		name: 'host',
+		now: now + 7000,
+	})
+	expect(fourth).toMatchObject({ ok: false, code: 'thread_limit' })
+
+	const restored = await setThreadNeverExpires({
+		db: env.DB,
+		threadId: first.thread.id,
+		neverExpires: false,
+		now: now + 8000,
+	})
+	if (!restored.ok) throw new Error(restored.error)
+	expect(restored.thread.never_expires_at).toBeNull()
+	expect(restored.thread.expires_at).toBeGreaterThan(now + 8000)
+})
+
+test('guest threads cannot be kept; host can hard-delete and free the IP slot', async () => {
+	const env = createTestEnv()
+	const now = Date.parse('2026-08-17T00:00:00Z')
+	const created = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: null,
+		creatorIp: '203.0.113.70',
+		name: 'host',
+		now,
+	})
+	if (!created.ok) throw new Error(created.error)
+	const keep = await setThreadNeverExpires({
+		db: env.DB,
+		threadId: created.thread.id,
+		neverExpires: true,
+		now: now + 1000,
+	})
+	expect(keep).toMatchObject({ ok: false, code: 'keep_forbidden' })
+
+	const joined = await joinThread({
+		db: env.DB,
+		joinToken: created.joinToken,
+		name: 'guest',
+		now: now + 2000,
+	})
+	if (!joined.ok) throw new Error(joined.error)
+	const guestDelete = await deleteThreadAsHost({
+		db: env.DB,
+		threadId: created.thread.id,
+		agent: joined.agent,
+		now: now + 3000,
+	})
+	expect(guestDelete).toMatchObject({ ok: false, code: 'not_host' })
+
+	const deleted = await deleteThreadAsHost({
+		db: env.DB,
+		threadId: created.thread.id,
+		agent: created.agent,
+		now: now + 3000,
+	})
+	if (!deleted.ok) throw new Error(deleted.error)
+	expect(deleted.thread.id).toBe(created.thread.id)
+
+	const gone = await listMessagesForView({
+		db: env.DB,
+		viewToken: await viewTokenFor(created.thread),
+		now: now + 4000,
+	})
+	expect(gone).toMatchObject({ ok: false, code: 'thread_not_found' })
+
+	const again = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: null,
+		creatorIp: '203.0.113.70',
+		name: 'next',
+		now: now + 5000,
+	})
+	expect(again.ok).toBe(true)
+})
+
+test('deleteThread removes members and messages; missing threads 404', async () => {
+	const env = createTestEnv()
+	const created = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		ownerUserId: null,
+		creatorIp: '198.51.100.70',
+		name: 'host',
+	})
+	if (!created.ok) throw new Error(created.error)
+	const deleted = await deleteThread({
+		db: env.DB,
+		threadId: created.thread.id,
+	})
+	if (!deleted.ok) throw new Error(deleted.error)
+	expect(await listThreadMembers(env.DB, created.thread.id)).toEqual([])
+	const missing = await deleteThread({
+		db: env.DB,
+		threadId: created.thread.id,
+	})
+	expect(missing).toMatchObject({ ok: false, code: 'thread_not_found' })
 })

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -56,6 +56,7 @@ export type ThreadRow = {
 	created_at: number
 	expires_at: number
 	archived_at: number | null
+	never_expires_at: number | null
 }
 
 const tokenBodyLen = 48
@@ -207,6 +208,31 @@ export function isThreadArchived(
 	return thread?.archived_at != null
 }
 
+export function isThreadNeverExpiring(
+	thread: { never_expires_at?: number | null } | null | undefined,
+) {
+	return thread?.never_expires_at != null
+}
+
+export function isThreadExpired(
+	thread: {
+		expires_at: number
+		never_expires_at?: number | null
+	},
+	now: number,
+) {
+	return !isThreadNeverExpiring(thread) && thread.expires_at <= now
+}
+
+/** Bind `now` for the `?`. Kept threads stay unexpired. */
+export function sqlThreadUnexpired(prefix = '') {
+	return `(${prefix}never_expires_at IS NOT NULL OR ${prefix}expires_at > ?)`
+}
+
+export function sqlThreadLive(prefix = '') {
+	return `${sqlThreadUnexpired(prefix)} AND ${prefix}archived_at IS NULL`
+}
+
 export function threadArchivedError(): DomainError {
 	return fail(
 		409,
@@ -341,7 +367,7 @@ function sanitizeIp(value: unknown) {
 export async function countLiveGuestThreads(db: D1Database, now = Date.now()) {
 	const row = await first<{ n: number }>(
 		db,
-		'SELECT COUNT(*) AS n FROM threads WHERE owner_user_id IS NULL AND expires_at > ? AND archived_at IS NULL',
+		`SELECT COUNT(*) AS n FROM threads WHERE owner_user_id IS NULL AND ${sqlThreadLive()}`,
 		now,
 	)
 	return row?.n ?? 0
@@ -354,7 +380,7 @@ export async function countGuestThreadsForIp(
 ) {
 	const row = await first<{ n: number }>(
 		db,
-		'SELECT COUNT(*) AS n FROM threads WHERE owner_user_id IS NULL AND creator_ip = ? AND expires_at > ? AND archived_at IS NULL',
+		`SELECT COUNT(*) AS n FROM threads WHERE owner_user_id IS NULL AND creator_ip = ? AND ${sqlThreadLive()}`,
 		ip,
 		now,
 	)
@@ -364,7 +390,7 @@ export async function countGuestThreadsForIp(
 export async function countOwnedThreads(db: D1Database, userId: string) {
 	const row = await first<{ n: number }>(
 		db,
-		'SELECT COUNT(*) AS n FROM threads WHERE owner_user_id = ? AND expires_at > ? AND archived_at IS NULL',
+		`SELECT COUNT(*) AS n FROM threads WHERE owner_user_id = ? AND ${sqlThreadLive()}`,
 		userId,
 		Date.now(),
 	)
@@ -643,7 +669,7 @@ export async function joinThread(input: {
 > {
 	const now = input.now ?? Date.now()
 	const thread = await getThreadByJoinToken(input.db, input.joinToken)
-	if (!thread || thread.expires_at <= now) {
+	if (!thread || isThreadExpired(thread, now)) {
 		return fail(404, 'thread_not_found', 'Thread not found or expired.')
 	}
 	const live = assertThreadLive(thread)
@@ -712,7 +738,7 @@ export async function requireMember(input: {
 		'SELECT * FROM threads WHERE id = ?',
 		input.threadId,
 	)
-	if (!thread || thread.expires_at <= now) {
+	if (!thread || isThreadExpired(thread, now)) {
 		return fail(404, 'thread_not_found', 'Thread not found or expired.')
 	}
 	const member = await first<{ agent_id: string }>(
@@ -803,7 +829,7 @@ export async function sendMessage(input: {
 	)
 	await run(
 		input.db,
-		'UPDATE threads SET expires_at = ? WHERE id = ?',
+		'UPDATE threads SET expires_at = ? WHERE id = ? AND never_expires_at IS NULL',
 		now + plan.retentionMs,
 		membership.thread.id,
 	)
@@ -941,7 +967,7 @@ export async function getThreadViewCard(input: {
 > {
 	const now = input.now ?? Date.now()
 	const thread = await getThreadByViewToken(input.db, input.viewToken)
-	if (!thread || thread.expires_at <= now) {
+	if (!thread || isThreadExpired(thread, now)) {
 		return fail(404, 'thread_not_found', 'Thread not found or expired.')
 	}
 	const planName = await planForOwner(input.db, thread.owner_user_id)
@@ -971,7 +997,7 @@ export async function listMessagesForView(input: {
 > {
 	const now = input.now ?? Date.now()
 	const thread = await getThreadByViewToken(input.db, input.viewToken)
-	if (!thread || thread.expires_at <= now) {
+	if (!thread || isThreadExpired(thread, now)) {
 		return fail(404, 'thread_not_found', 'Thread not found or expired.')
 	}
 	const planName = await planForOwner(input.db, thread.owner_user_id)
@@ -1029,7 +1055,7 @@ export async function archiveThread(input: {
 		'SELECT * FROM threads WHERE id = ?',
 		input.threadId,
 	)
-	if (!thread || thread.expires_at <= now) {
+	if (!thread || isThreadExpired(thread, now)) {
 		return fail(404, 'thread_not_found', 'Thread not found or expired.')
 	}
 	if (isThreadArchived(thread)) return { ok: true, thread }
@@ -1074,6 +1100,103 @@ export async function archiveThreadAsHost(input: {
 		db: input.db,
 		threadId: membership.thread.id,
 		now: input.now,
+	})
+}
+
+export async function setThreadNeverExpires(input: {
+	db: D1Database
+	threadId: string
+	neverExpires: boolean
+	now?: number
+}): Promise<DomainError | DomainOk<{ thread: ThreadRow }>> {
+	const now = input.now ?? Date.now()
+	const thread = await first<ThreadRow>(
+		input.db,
+		'SELECT * FROM threads WHERE id = ?',
+		input.threadId,
+	)
+	if (!thread || isThreadExpired(thread, now)) {
+		return fail(404, 'thread_not_found', 'Thread not found or expired.')
+	}
+	if (!thread.owner_user_id) {
+		return fail(
+			403,
+			'keep_forbidden',
+			'Guest threads expire on the guest retention clock. Sign in to keep a thread forever.',
+		)
+	}
+	if (input.neverExpires) {
+		if (isThreadNeverExpiring(thread)) return { ok: true, thread }
+		await run(
+			input.db,
+			'UPDATE threads SET never_expires_at = ? WHERE id = ?',
+			now,
+			thread.id,
+		)
+	} else {
+		if (!isThreadNeverExpiring(thread)) return { ok: true, thread }
+		const planName = await planForOwner(input.db, thread.owner_user_id)
+		await run(
+			input.db,
+			'UPDATE threads SET never_expires_at = NULL, expires_at = ? WHERE id = ?',
+			now + getPlan(planName).retentionMs,
+			thread.id,
+		)
+	}
+	const updated = await first<ThreadRow>(
+		input.db,
+		'SELECT * FROM threads WHERE id = ?',
+		thread.id,
+	)
+	if (!updated) {
+		return fail(500, 'keep_failed', 'Could not update thread retention.')
+	}
+	return { ok: true, thread: updated }
+}
+
+async function cascadeDeleteThread(db: D1Database, threadId: string) {
+	await run(db, 'DELETE FROM messages WHERE thread_id = ?', threadId)
+	await run(db, 'DELETE FROM thread_members WHERE thread_id = ?', threadId)
+	await run(db, 'DELETE FROM agents WHERE thread_id = ?', threadId)
+	await run(db, 'DELETE FROM threads WHERE id = ?', threadId)
+}
+
+export async function deleteThread(input: {
+	db: D1Database
+	threadId: string
+}): Promise<DomainError | DomainOk<{ thread: ThreadRow }>> {
+	const thread = await first<ThreadRow>(
+		input.db,
+		'SELECT * FROM threads WHERE id = ?',
+		input.threadId,
+	)
+	if (!thread) {
+		return fail(404, 'thread_not_found', 'Thread not found or expired.')
+	}
+	await cascadeDeleteThread(input.db, thread.id)
+	return { ok: true, thread }
+}
+
+export async function deleteThreadAsHost(input: {
+	db: D1Database
+	threadId: string
+	agent: AgentRow
+	now?: number
+}): Promise<DomainError | DomainOk<{ thread: ThreadRow }>> {
+	const membership = await requireMember({
+		db: input.db,
+		threadId: input.threadId,
+		agent: input.agent,
+		now: input.now,
+	})
+	if (!membership.ok) return membership
+	const host = await getHostAgent(input.db, membership.thread.id)
+	if (!host || host.id !== input.agent.id) {
+		return fail(403, 'not_host', 'Only the host can delete this thread.')
+	}
+	return deleteThread({
+		db: input.db,
+		threadId: membership.thread.id,
 	})
 }
 
@@ -1139,14 +1262,11 @@ export async function revokeAgent(input: {
 export async function purgeExpired(db: D1Database, now = Date.now()) {
 	const expired = await all<{ id: string }>(
 		db,
-		'SELECT id FROM threads WHERE expires_at <= ?',
+		'SELECT id FROM threads WHERE never_expires_at IS NULL AND expires_at <= ?',
 		now,
 	)
 	for (const thread of expired) {
-		await run(db, 'DELETE FROM messages WHERE thread_id = ?', thread.id)
-		await run(db, 'DELETE FROM thread_members WHERE thread_id = ?', thread.id)
-		await run(db, 'DELETE FROM agents WHERE thread_id = ?', thread.id)
-		await run(db, 'DELETE FROM threads WHERE id = ?', thread.id)
+		await cascadeDeleteThread(db, thread.id)
 	}
 	return expired.length
 }

--- a/src/user-api.ts
+++ b/src/user-api.ts
@@ -8,14 +8,18 @@ import { type AppEnv, appBaseUrl } from '#src/env.ts'
 import {
 	archiveThread,
 	createThread,
+	deleteThread,
 	getHostAgent,
 	isThreadArchived,
+	isThreadNeverExpiring,
 	joinThread,
 	listMessages,
 	listThreadMembers,
 	maybeDispatchWebhook,
 	sendMessage,
+	setThreadNeverExpires,
 	setWebhook,
+	sqlThreadLive,
 	type ThreadRow,
 	type UserRow,
 } from '#src/threads.ts'
@@ -38,12 +42,15 @@ function threadJson(thread: {
 	created_at: number
 	expires_at: number
 	archived_at?: number | null
+	never_expires_at?: number | null
 }) {
+	const neverExpires = isThreadNeverExpiring(thread)
 	return {
 		id: thread.id,
 		purpose: thread.purpose,
 		created_at: new Date(thread.created_at).toISOString(),
-		expires_at: new Date(thread.expires_at).toISOString(),
+		expires_at: neverExpires ? null : new Date(thread.expires_at).toISOString(),
+		never_expires: neverExpires,
 		archived: isThreadArchived(thread),
 	}
 }
@@ -88,7 +95,7 @@ async function listOwnedThreads(env: AppEnv, user: UserRow) {
 			 SELECT COUNT(*) FROM thread_members m WHERE m.thread_id = t.id
 		 ) AS member_count
 		 FROM threads t
-		 WHERE t.owner_user_id = ? AND t.expires_at > ? AND t.archived_at IS NULL
+		 WHERE t.owner_user_id = ? AND ${sqlThreadLive('t.')}
 		 ORDER BY t.created_at DESC`,
 		user.id,
 		Date.now(),
@@ -241,6 +248,45 @@ export async function handleUserApi(
 		if (!archived.ok) return errorResponse(archived)
 		await maybeCloseThreadView(env, archived.thread.id, ctx)
 		return json({ ok: true, thread: threadJson(archived.thread) })
+	}
+
+	const keep = url.pathname.match(/^\/api\/threads\/([^/]+)\/keep$/)
+	if (keep?.[1] && request.method === 'POST') {
+		const owned = await requireOwnedThread(env, user, keep[1])
+		if (!owned.ok) return owned.response
+		const kept = await setThreadNeverExpires({
+			db: env.DB,
+			threadId: owned.thread.id,
+			neverExpires: true,
+		})
+		if (!kept.ok) return errorResponse(kept)
+		return json({ ok: true, thread: threadJson(kept.thread) })
+	}
+
+	const expire = url.pathname.match(/^\/api\/threads\/([^/]+)\/expire$/)
+	if (expire?.[1] && request.method === 'POST') {
+		const owned = await requireOwnedThread(env, user, expire[1])
+		if (!owned.ok) return owned.response
+		const restored = await setThreadNeverExpires({
+			db: env.DB,
+			threadId: owned.thread.id,
+			neverExpires: false,
+		})
+		if (!restored.ok) return errorResponse(restored)
+		return json({ ok: true, thread: threadJson(restored.thread) })
+	}
+
+	const remove = url.pathname.match(/^\/api\/threads\/([^/]+)\/delete$/)
+	if (remove?.[1] && request.method === 'POST') {
+		const owned = await requireOwnedThread(env, user, remove[1])
+		if (!owned.ok) return owned.response
+		const deleted = await deleteThread({
+			db: env.DB,
+			threadId: owned.thread.id,
+		})
+		if (!deleted.ok) return errorResponse(deleted)
+		await maybeCloseThreadView(env, deleted.thread.id, ctx)
+		return json({ ok: true, deleted: true, thread: threadJson(deleted.thread) })
 	}
 
 	return json({ ok: false, error: 'Not found.', code: 'not_found' }, 404)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Owned threads can be marked so they never expire, and anyone who can close a room can also hard-delete it.

## What changed

- **Keep forever** — owner `POST /api/threads/{id}/keep` (and MCP `keep_thread`) sets `never_expires_at`. Guest threads cannot be kept. Restore normal retention with `POST /api/threads/{id}/expire`.
- **Still counts as live** — kept threads stay in the live-thread count until they are archived or deleted. Purge skips them even if `expires_at` is in the past.
- **Hard delete** — owner `POST /api/threads/{id}/delete` and host `POST /v1/delete` cascade-delete members, guest agents, and messages immediately (same as expiry purge).
- **Account UI** — Keep forever / Allow to expire, Close thread, and Delete thread. Delete waits 10 seconds in the browser and offers Undo; without JS the form posts immediately.

## Surfaces

- Account page forms
- OAuth API + MCP (`keep_thread`, `expire_thread`, `delete_thread`)
- Guest host `POST /v1/delete`

Watch pages and OG cards show infinite retention for kept threads. Docs and primitives are updated.

## Validation

`npm run validate` is green locally: format, lint, typecheck, and 101 tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d34e098-f855-44da-b5bb-5f3edbdbe281?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d34e098-f855-44da-b5bb-5f3edbdbe281&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account owners can keep threads indefinitely, restore expiration, archive, or permanently delete them.
  * Hosts can permanently delete guest threads.
  * Added retention and deletion controls to account pages, APIs, and MCP tools.
  * Non-expiring threads now display no expiration date and remain subject to live-thread limits.

* **Bug Fixes**
  * Expiration cleanup and related thread actions now correctly respect retained threads.
  * Deleting a thread removes associated data and frees guest access limits.

* **Documentation**
  * Added guidance for thread retention, archiving, restoration, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->