### PR TITLE
Add Kody conduct, orchestrate, and ship-pr skills

### DIFF
--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: conduct
+description: >
+  Coordinate a fleet of cloud agents across separate environments for large
+  multi-track programs (migrations, purges, upgrades). The conductor audits,
+  partitions, spawns one agent per track, monitors, and QAs — but implements
+  nothing. Use only when work needs multiple environments; otherwise load
+  orchestrate or implement directly.
+---
+
+# Conduct
+
+From [Kody](https://github.com/kentcdodds/kody/blob/main/.agents/skills/conduct/SKILL.md),
+adapted for kody.exchange.
+
+You spawn cloud agents via `kody:@kentcdodds/cursor/agents` — one per track,
+each in its own environment. You never write the code yourself.
+
+## When to use
+
+Conduct only for **two or more environments** (independent branches/PRs,
+conflicting ownership, long parallel tracks). Otherwise demote:
+
+- one coherent track → load `orchestrate` or implement
+- fits one checkout/PR → orchestrate or implement, not a fleet
+
+Do not spawn a one-agent "fleet."
+
+## Defaults (override only if the user says so)
+
+- **Escalate before fleet.** Analysis → multi-track program needs explicit
+  approve: tracks, wall-clock, stop criteria, out-of-scope.
+- **Tracks implement by default.** Hand `orchestrate` only for clear parallel
+  ROI inside a track. Sequential slices → one implementer.
+- **Risk posture in every kickoff.** Pre-launch / small-N: evidence or canary
+  gates, soak ≤1h unless the user opts in. No 24h calendar gates for reversible
+  steps. Production / irreversible: say so and raise the bar.
+- **Expand owns contract.** No `STATUS: done` after expand-only — same kickoff
+  or a scheduled wake with an owner.
+- **Stop when the goal is met.** Cleanup/drop is a later ask unless the user
+  says finish it now.
+- **Ship autonomously** under the user's shipping policy; hand `ship-pr` when
+  agents may merge. High-risk park only when the user requires it — then ask
+  once, list PRs, schedule a self-wake (don't sleep-poll).
+- **Fewer, larger PRs** when posture allows. Fresh branch per shippable slice;
+  don't thrash one long-lived branch across a dozen micro-PRs.
+
+## This repo
+
+- Merge GitHub mutations as Kent (`account: 'kent'` on `@kentcdodds/github`).
+- No PR preview deploys. After merge, watch production Deploy and
+  `GET https://kody.exchange/health` until `commit` matches the merge SHA.
+- Repository: `https://github.com/kentcdodds/kody-exchange`.
+
+## Invariants
+
+**PR ownership.** Every code-changing agent pushes and creates/updates its own
+PR via Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before its final
+response. Never have Kody/workflows/GitHub create the initial PR. State this in
+every kickoff.
+
+**Report-back (wake-ups, not polling).** End of every run — done, partial, or
+blocked — the agent wakes the conductor:
+
+```javascript
+import { createRun } from 'kody:@kentcdodds/cursor/runs'
+await createRun({
+	agentId: '<CONDUCTOR_AGENT_ID>',
+	prompt:
+		'<track> report: STATUS; shipped (PR links); evidence; remains + gate times.',
+})
+```
+
+Get your id from cursor-cloud `run-info` and paste it into kickoffs. Also keep a
+`## Conductor report` section on each PR (durable record).
+
+Topology: `createRun` wake-ups work only if the conductor is an API-created
+cloud agent. An interactive chat conductor rejects them (400) — use Discord (or
+another channel you check) as primary.
+
+**Time gates → one-shot jobs**, not `sleep`:
+
+```javascript
+import { kody } from 'kody:runtime'
+await kody.job_schedule({
+	name: 'wake-<track>-after-<gate>',
+	description: 'Resume <track> when <gate> elapses.',
+	schedule: { type: 'once', run_at: '<ISO datetime>' },
+	code: "import { createRun } from 'kody:@kentcdodds/cursor/runs'\nexport default async function main() { return await createRun({ agentId: '<AGENT_ID>', prompt: '<gate> elapsed; verify evidence, then proceed.' }) }",
+})
+```
+
+Schedule the same against your own agent id so the program survives session end.
+Cancel superseded jobs with `job_delete`.
+
+## Loop
+
+1. Confirm multi-environment need (else demote).
+2. Audit — explore agents for verified findings; check live facts yourself.
+3. Partition by **file conflict**, not theme. Name each track's out-of-scope
+   (what siblings own). One track after partition → demote.
+4. Size agents: implementer by default; `orchestrate` only when fan-out pays.
+5. State shipping policy + risk posture + PR invariant + report-back (with your
+   real agent id) + falsifiable done-definition in every kickoff.
+6. Dispatch, then **end your turn**. Wake-ups/jobs drive the loop. Poll only for
+   silent agents. Verify claims against main before acting.
+7. Nudge idle agents with `createRun` (409 while mid-run — retry or schedule).
+   New scope → nearest idle owner; spawn only for new territory.
+8. Final QA is yours — grep main, check deploys. Never report done from claims.
+
+## Companions
+
+Load with the repo skills and embed when useful: `orchestrate` (in-track
+fan-out), `ship-pr` (merge authority). Skip when the track is small or PRs are
+review-only.
+
+## Spawn sketch
+
+```javascript
+import { createAgent } from 'kody:@kentcdodds/cursor/agents'
+import { createRun } from 'kody:@kentcdodds/cursor/runs'
+
+export default async function main() {
+	const { agent } = await createAgent({
+		model: 'gpt-5.6-sol',
+		repository: 'https://github.com/kentcdodds/kody-exchange',
+		ref: 'main',
+		autoCreatePR: true,
+		name: 'track-short-name',
+		prompt: '…self-contained kickoff with report-back + your conductor id…',
+	})
+	// await createRun({ agentId: agent.id, prompt: 'follow-up…' })
+	return agent
+}
+```
+
+Prefer `gh` in-shell for PR/deploy checks; use `execute` for agent lifecycle.
+Include this in every agent creation prompt: if the task results in code
+changes, the agent itself MUST push its branch and create or update the pull
+request using Cursor Cloud `ManagePullRequest` before finishing.

--- a/.agents/skills/orchestrate/SKILL.md
+++ b/.agents/skills/orchestrate/SKILL.md
@@ -10,6 +10,9 @@ description: >
 
 # Orchestrate
 
+From [Kody](https://github.com/kentcdodds/kody/blob/main/.agents/skills/orchestrate/SKILL.md),
+adapted for kody.exchange.
+
 Fan out **sub-agents inside one environment** (shared checkout). For separate
 environments/PRs, use `conduct`.
 
@@ -46,3 +49,7 @@ optimized for cheap/fast execution.
 Keep it short: goals + constraints + out-of-scope; "you orchestrate, don't bulk
 code"; preferred implementer model; single-environment (not conduct); done =
 falsifiable. Point at this skill.
+
+Every code-changing agent must push its branch and create or update the pull
+request with Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before
+finishing. Do not have Kody open the PR.

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -2,12 +2,15 @@
 name: ship-pr
 description: >
   Babysit a PR: iterate with AI reviewers and CI until green, get it ready,
-  optionally squash-merge as Kody and watch the deploy, then send a Discord
+  optionally squash-merge as Kent and watch the deploy, then send a Discord
   summary. Medium risk waits for AI reviewer(s) and addresses valid feedback.
   Use when a pull request needs to be shepherded to done.
 ---
 
 # Ship PR
+
+From [Kody](https://github.com/kentcdodds/kody/blob/main/.agents/skills/ship-pr/SKILL.md),
+adapted for kody.exchange.
 
 ## Risk → merge authority
 
@@ -35,13 +38,16 @@ CodeRabbit when the change is **high** risk (or the user explicitly asks).
 ## Loop
 
 1. Mark ready — `kody:@kentcdodds/github/pr/set-review-status`
-   `{ prUrl, status: 'ready' }` (or owner/repo/prNumber).
+   `{ prUrl, status: 'ready', account: 'kent' }` (or owner/repo/prNumber).
 2. Wait for CI — `gh pr checks` (or compose `loop-on-ci` / `fix-ci`).
 3. Fix failures; for **medium+**, wait on AI reviewer(s) (Bugbot first; see
    above for CodeRabbit) and address valid feedback. Rebase only when actually
    unmergeable.
 4. Green + (medium+: valid feedback cleared) → break.
 5. Push → repeat.
+
+There are no PR preview deploys here. Do not run a kody.codes-style
+`preview:manual-test`.
 
 ## Gates ≠ CI
 
@@ -53,9 +59,16 @@ Batch related expand steps into fewer PRs when risk posture allows.
 
 ## Merge / deploy
 
+Merge GitHub mutations as Kent (`account: 'kent'` on `@kentcdodds/github`).
+kody-bot does not have admin here.
+
 When policy + risk allow: squash-merge via `kody:@kentcdodds/github/pr/merge`
-`{ prUrl, mergeMethod: 'squash' }`, watch deploy. Useful: `pr/get-checks`,
+`{ prUrl, mergeMethod: 'squash', account: 'kent' }`. Useful: `pr/get-checks`,
 `request`, `graphql` on the same package.
+
+After merge, watch the production Deploy workflow (it starts after Validate
+succeeds on `main` via `workflow_run`). Then `GET https://kody.exchange/health`
+until `commit` matches the merge SHA.
 
 ## Done → Discord
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This file is brief. Skills and docs:
 
 - Orchestrate (single-environment fan-out):
   [`.agents/skills/orchestrate/SKILL.md`](./.agents/skills/orchestrate/SKILL.md)
+- Conduct (multi-environment fleet):
+  [`.agents/skills/conduct/SKILL.md`](./.agents/skills/conduct/SKILL.md)
 - Ship a PR (CI, reviewers, merge, Discord):
   [`.agents/skills/ship-pr/SKILL.md`](./.agents/skills/ship-pr/SKILL.md)
 - Setup and secrets:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ask the human for `purpose` and `name` before that POST — do not invent them. 
 
 ## Docs
 
-- [Agent index](./AGENTS.md) (orchestrate + ship-pr skills)
+- [Agent index](./AGENTS.md) (orchestrate, conduct, and ship-pr skills)
 - [Primitives and invariants](./docs/contributing/architecture/primitives.md)
 - [Setup](./docs/contributing/setup.md)
 - [Agent use](./docs/use/index.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Kody's official agent skills from [kentcdodds/kody](https://github.com/kentcdodds/kody/tree/main/.agents/skills), adapted for this repo.

## Skills

- **conduct** (new) — multi-environment fleet conductor. Spawn via `kody:@kentcdodds/cursor/agents`; do not implement in the conductor.
- **orchestrate** — single-environment fan-out. Notes the `ManagePullRequest` ownership rule.
- **ship-pr** — CI, Bugbot, squash-merge as Kent, watch production Deploy + `/health`, Discord summary.

Repo-specific adaptations: `account: 'kent'`, no preview deploys, watch `https://kody.exchange/health`.

`AGENTS.md` and `README.md` now index all three.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d34e098-f855-44da-b5bb-5f3edbdbe281?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d34e098-f855-44da-b5bb-5f3edbdbe281&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

