### PR TITLE
Fix OAuth audience split so Kody tokens work on /api and /mcp

### DIFF
--- a/src/oauth-authorize.ts
+++ b/src/oauth-authorize.ts
@@ -3,7 +3,10 @@ import { type AppEnv, appBaseUrl } from '#src/env.ts'
 import { escapeHtml, layout } from '#src/html.ts'
 import { oauthPaths, oauthScopes } from '#src/oauth-paths.ts'
 import { getPkceValidationError } from '#src/oauth-pkce.ts'
-import { type OAuthAuthRequest, defaultMcpResource } from '#src/oauth-user.ts'
+import {
+	type OAuthAuthRequest,
+	resolveAuthorizationResource,
+} from '#src/oauth-user.ts'
 
 function html(body: string, status = 200, extra?: HeadersInit) {
 	const headers = new Headers(extra)
@@ -20,9 +23,10 @@ function resolveScopes(requested: Array<string>) {
 }
 
 function applyDefaultResource(authRequest: OAuthAuthRequest, origin: string) {
-	if (authRequest.resource === undefined) {
-		authRequest.resource = defaultMcpResource(origin)
-	}
+	authRequest.resource = resolveAuthorizationResource(
+		authRequest.resource,
+		origin,
+	)
 	return authRequest
 }
 

--- a/src/oauth-paths.ts
+++ b/src/oauth-paths.ts
@@ -17,8 +17,9 @@ export const protectedResourceMetadataPath =
 
 export function isProtectedResourceMetadataPath(pathname: string) {
 	// Root + /mcp only. Leave /api to OAuthProvider so that document still
-	// advertises https://kody.exchange/api; an /mcp audience does not cover
-	// /api/* on the provider's apiRoute check.
+	// advertises https://kody.exchange/api. Omitted or origin-only authorize
+	// resources mint the shared product audience (origin, /api, /mcp) so
+	// apiRoute accepts the token; an explicit /mcp audience stays MCP-scoped.
 	return (
 		pathname === protectedResourceMetadataPath ||
 		pathname === `${protectedResourceMetadataPath}${mcpResourcePath}`

--- a/src/oauth-user.ts
+++ b/src/oauth-user.ts
@@ -38,7 +38,7 @@ export type OAuthAuthRequest = {
 	state?: string
 	codeChallenge?: string
 	codeChallengeMethod?: string
-	resource?: string
+	resource?: string | Array<string>
 }
 
 export type OAuthClientInfo = {
@@ -93,6 +93,38 @@ export function defaultMcpResource(origin: string) {
 
 export function canonicalizeAudience(value: string) {
 	return value.replace(/\/+$/, '')
+}
+
+export function sharedProductResources(origin: string) {
+	const base = canonicalizeAudience(origin)
+	return [base, `${base}${apiResourcePath}`, `${base}${mcpResourcePath}`]
+}
+
+function resourceValues(resource: string | Array<string> | undefined) {
+	if (resource === undefined) return []
+	return typeof resource === 'string' ? [resource] : resource
+}
+
+export function isSharedProductResource(
+	resource: string | Array<string> | undefined,
+	origin: string,
+) {
+	if (resource === undefined) return true
+	const values = resourceValues(resource)
+	return (
+		values.length === 1 &&
+		canonicalizeAudience(values[0] ?? '') === canonicalizeAudience(origin)
+	)
+}
+
+export function resolveAuthorizationResource(
+	resource: string | Array<string> | undefined,
+	origin: string,
+) {
+	if (isSharedProductResource(resource, origin)) {
+		return sharedProductResources(origin)
+	}
+	return resource
 }
 
 export function audienceMatches(

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -5,12 +5,15 @@ import {
 	audienceMatches,
 	type OAuthAuthRequest,
 	type OAuthHelpers,
+	resolveAuthorizationResource,
+	sharedProductResources,
 } from '#src/oauth-user.ts'
 import {
 	createSignedInUser,
 	createTestEnv,
 	request,
 } from '#src/test-support.ts'
+import worker from '#src/worker.ts'
 
 function authRequest(
 	overrides: Partial<OAuthAuthRequest> = {},
@@ -58,6 +61,24 @@ test('audienceMatches accepts origin, /mcp, /api, and trailing slashes', () => {
 	expect(audienceMatches([`${origin}/api`], origin)).toBe(true)
 	expect(audienceMatches(`${origin}/other`, origin)).toBe(false)
 	expect(audienceMatches(['https://example.com'], origin)).toBe(false)
+})
+
+test('omitted or origin resource becomes the shared product audience', () => {
+	const origin = 'https://kody.exchange'
+	const shared = sharedProductResources(origin)
+	expect(shared).toEqual([origin, `${origin}/api`, `${origin}/mcp`])
+	expect(resolveAuthorizationResource(undefined, origin)).toEqual(shared)
+	expect(resolveAuthorizationResource(origin, origin)).toEqual(shared)
+	expect(resolveAuthorizationResource(`${origin}/`, origin)).toEqual(shared)
+	expect(resolveAuthorizationResource(`${origin}/mcp`, origin)).toBe(
+		`${origin}/mcp`,
+	)
+	expect(resolveAuthorizationResource(`${origin}/api`, origin)).toBe(
+		`${origin}/api`,
+	)
+	expect(resolveAuthorizationResource('https://evil.example/mcp', origin)).toBe(
+		'https://evil.example/mcp',
+	)
 })
 
 test('protected resource metadata advertises /mcp', async () => {
@@ -153,6 +174,74 @@ test('signed-in owner can approve an OAuth client', async () => {
 	expect(approved.headers.get('location')).toBe(
 		'https://kody.codes/connect/oauth?code=ok&state=state-1',
 	)
+})
+
+test('authorize without resource mints the shared product audience, not /mcp-only', async () => {
+	const origin = 'https://kody.exchange'
+	let completed: OAuthAuthRequest | undefined
+	const env = createTestEnv({
+		OAUTH_PROVIDER: mockHelpers({
+			completeAuthorization: async (input) => {
+				completed = input.request
+				return {
+					redirectTo: 'https://kody.codes/connect/oauth?code=ok&state=state-1',
+				}
+			},
+		}),
+	})
+	const owner = await createSignedInUser(env)
+	const approved = await handleRequest(
+		request(`${oauthPaths.authorize}?client_id=client_1`, {
+			method: 'POST',
+			headers: {
+				cookie: owner.cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf: owner.csrf,
+				decision: 'approve',
+			}),
+		}),
+		env,
+	)
+	expect(approved.status).toBe(302)
+	expect(completed?.resource).toEqual(sharedProductResources(origin))
+	expect(completed?.resource).not.toBe(`${origin}/mcp`)
+})
+
+test('authorize with explicit /mcp keeps an MCP-scoped resource', async () => {
+	let completed: OAuthAuthRequest | undefined
+	const env = createTestEnv({
+		OAUTH_PROVIDER: mockHelpers(
+			{
+				completeAuthorization: async (input) => {
+					completed = input.request
+					return {
+						redirectTo:
+							'https://kody.codes/connect/oauth?code=ok&state=state-1',
+					}
+				},
+			},
+			authRequest({ resource: 'https://kody.exchange/mcp' }),
+		),
+	})
+	const owner = await createSignedInUser(env)
+	const approved = await handleRequest(
+		request(`${oauthPaths.authorize}?client_id=client_1`, {
+			method: 'POST',
+			headers: {
+				cookie: owner.cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf: owner.csrf,
+				decision: 'approve',
+			}),
+		}),
+		env,
+	)
+	expect(approved.status).toBe(302)
+	expect(completed?.resource).toBe('https://kody.exchange/mcp')
 })
 
 test('OAuth user API creates, lists, sends, and sets a webhook', async () => {
@@ -429,4 +518,241 @@ test('OAuth user API can keep and hard-delete a thread', async () => {
 	}
 	expect(mcpPayload.ok).toBe(false)
 	expect(mcpPayload.code).toBe('not_found')
+})
+
+function executionContext(): ExecutionContext {
+	return {
+		waitUntil() {},
+		passThroughOnException() {},
+		props: {},
+	} as unknown as ExecutionContext
+}
+
+async function pkcePair() {
+	const verifierBytes = crypto.getRandomValues(new Uint8Array(32))
+	const verifier = Buffer.from(verifierBytes).toString('base64url')
+	const digest = await crypto.subtle.digest(
+		'SHA-256',
+		new TextEncoder().encode(verifier),
+	)
+	return { verifier, challenge: Buffer.from(digest).toString('base64url') }
+}
+
+type TokenResponse = {
+	access_token: string
+	refresh_token?: string
+	token_type?: string
+	resource?: string | Array<string>
+	error?: string
+	error_description?: string
+}
+
+async function registerPublicClient(env: ReturnType<typeof createTestEnv>) {
+	const response = await worker.fetch(
+		request(oauthPaths.register, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				client_name: 'kody.codes',
+				redirect_uris: ['https://kody.codes/connect/oauth'],
+				token_endpoint_auth_method: 'none',
+				grant_types: ['authorization_code', 'refresh_token'],
+				response_types: ['code'],
+			}),
+		}),
+		env,
+		executionContext(),
+	)
+	expect(response.status).toBe(201)
+	return (await response.json()) as { client_id: string }
+}
+
+async function approveAuthorization(
+	env: ReturnType<typeof createTestEnv>,
+	input: {
+		clientId: string
+		challenge: string
+		resource?: string
+	},
+) {
+	const owner = await createSignedInUser(env)
+	const authorize = new URL('https://kody.exchange/oauth/authorize')
+	authorize.searchParams.set('response_type', 'code')
+	authorize.searchParams.set('client_id', input.clientId)
+	authorize.searchParams.set('redirect_uri', 'https://kody.codes/connect/oauth')
+	authorize.searchParams.set('scope', 'profile threads')
+	authorize.searchParams.set('state', 'state-1')
+	authorize.searchParams.set('code_challenge', input.challenge)
+	authorize.searchParams.set('code_challenge_method', 'S256')
+	if (input.resource) authorize.searchParams.set('resource', input.resource)
+
+	const page = await worker.fetch(
+		new Request(authorize, { headers: { cookie: owner.cookie } }),
+		env,
+		executionContext(),
+	)
+	expect(page.status).toBe(200)
+
+	const approved = await worker.fetch(
+		new Request(authorize, {
+			method: 'POST',
+			headers: {
+				cookie: owner.cookie,
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				csrf: owner.csrf,
+				decision: 'approve',
+			}),
+		}),
+		env,
+		executionContext(),
+	)
+	expect(approved.status).toBe(302)
+	const location = approved.headers.get('location')
+	expect(location).toBeTruthy()
+	const redirected = new URL(location ?? '')
+	const code = redirected.searchParams.get('code')
+	expect(code).toBeTruthy()
+	return { owner, code: code ?? '' }
+}
+
+async function exchangeToken(
+	env: ReturnType<typeof createTestEnv>,
+	input: {
+		clientId: string
+		code?: string
+		verifier?: string
+		refreshToken?: string
+		resource?: string
+	},
+) {
+	const body = new URLSearchParams({ client_id: input.clientId })
+	if (input.refreshToken) {
+		body.set('grant_type', 'refresh_token')
+		body.set('refresh_token', input.refreshToken)
+	} else {
+		body.set('grant_type', 'authorization_code')
+		body.set('code', input.code ?? '')
+		body.set('redirect_uri', 'https://kody.codes/connect/oauth')
+		body.set('code_verifier', input.verifier ?? '')
+	}
+	if (input.resource) body.set('resource', input.resource)
+	const response = await worker.fetch(
+		request(oauthPaths.token, {
+			method: 'POST',
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+			body,
+		}),
+		env,
+		executionContext(),
+	)
+	return {
+		status: response.status,
+		body: (await response.json()) as TokenResponse,
+	}
+}
+
+async function bearerGet(
+	env: ReturnType<typeof createTestEnv>,
+	path: string,
+	token: string,
+) {
+	return worker.fetch(
+		request(path, { headers: { authorization: `Bearer ${token}` } }),
+		env,
+		executionContext(),
+	)
+}
+
+test('resource-less authorize token works on /api and /mcp, and refresh stays valid', async () => {
+	const origin = 'https://kody.exchange'
+	const env = createTestEnv()
+	const client = await registerPublicClient(env)
+	const pkce = await pkcePair()
+	const { owner, code } = await approveAuthorization(env, {
+		clientId: client.client_id,
+		challenge: pkce.challenge,
+	})
+	const issued = await exchangeToken(env, {
+		clientId: client.client_id,
+		code,
+		verifier: pkce.verifier,
+	})
+	expect(issued.status).toBe(200)
+	expect(issued.body.access_token).toBeTruthy()
+	expect(issued.body.refresh_token).toBeTruthy()
+	expect(issued.body.resource).toEqual(sharedProductResources(origin))
+	expect(issued.body.resource).not.toBe(`${origin}/mcp`)
+
+	const api = await bearerGet(env, '/api/me', issued.body.access_token)
+	expect(api.status).toBe(200)
+	const apiBody = (await api.json()) as {
+		ok: boolean
+		user: { id: string; login: string }
+	}
+	expect(apiBody.ok).toBe(true)
+	expect(apiBody.user.id).toBe(owner.user.id)
+	expect(apiBody.user.login).toBe(owner.user.login)
+
+	const threads = await bearerGet(env, '/api/threads', issued.body.access_token)
+	expect(threads.status).toBe(200)
+
+	const mcp = await bearerGet(env, '/mcp', issued.body.access_token)
+	expect(mcp.status).toBe(200)
+	const mcpBody = (await mcp.json()) as {
+		ok: boolean
+		user: { login: string }
+		tools: Array<string>
+	}
+	expect(mcpBody.ok).toBe(true)
+	expect(mcpBody.user.login).toBe(owner.user.login)
+	expect(mcpBody.tools).toContain('list_threads')
+
+	const refreshResources = [undefined, origin, `${origin}/api`, `${origin}/mcp`]
+	let refreshToken = issued.body.refresh_token ?? ''
+	for (const resource of refreshResources) {
+		const refreshed = await exchangeToken(env, {
+			clientId: client.client_id,
+			refreshToken,
+			resource,
+		})
+		expect(refreshed.status).toBe(200)
+		expect(refreshed.body.error).not.toBe('invalid_grant')
+		expect(refreshed.body.access_token).toBeTruthy()
+		expect(refreshed.body.refresh_token).toBeTruthy()
+		refreshToken = refreshed.body.refresh_token ?? refreshToken
+	}
+})
+
+test('explicit /mcp authorize still works for MCP and stays API-scoped', async () => {
+	const origin = 'https://kody.exchange'
+	const env = createTestEnv()
+	const client = await registerPublicClient(env)
+	const pkce = await pkcePair()
+	const { code } = await approveAuthorization(env, {
+		clientId: client.client_id,
+		challenge: pkce.challenge,
+		resource: `${origin}/mcp`,
+	})
+	const issued = await exchangeToken(env, {
+		clientId: client.client_id,
+		code,
+		verifier: pkce.verifier,
+		resource: `${origin}/mcp`,
+	})
+	expect(issued.status).toBe(200)
+	expect(issued.body.resource).toBe(`${origin}/mcp`)
+
+	const mcp = await bearerGet(env, '/mcp', issued.body.access_token)
+	expect(mcp.status).toBe(200)
+
+	const api = await bearerGet(env, '/api/me', issued.body.access_token)
+	expect(api.status).toBe(401)
+	const apiBody = (await api.json()) as {
+		error: string
+		error_description?: string
+	}
+	expect(apiBody.error).toBe('invalid_token')
+	expect(apiBody.error_description).toContain('audience')
 })

--- a/src/test-support.ts
+++ b/src/test-support.ts
@@ -88,11 +88,18 @@ function createD1(db: DatabaseSync): D1Database {
 class MemoryKv {
 	#map = new Map<string, string>()
 
-	async get(key: string) {
-		return this.#map.get(key) ?? null
+	async get(key: string, options?: { type?: string }) {
+		const value = this.#map.get(key)
+		if (value === undefined) return null
+		if (options?.type === 'json') return JSON.parse(value) as unknown
+		return value
 	}
 
-	async put(key: string, value: string) {
+	async put(
+		key: string,
+		value: string,
+		_options?: { expirationTtl?: number; expiration?: number },
+	) {
 		this.#map.set(key, value)
 	}
 
@@ -100,8 +107,21 @@ class MemoryKv {
 		this.#map.delete(key)
 	}
 
-	async list() {
-		return { keys: [...this.#map.keys()].map((name) => ({ name })) }
+	async list(options?: { prefix?: string; cursor?: string; limit?: number }) {
+		const prefix = options?.prefix ?? ''
+		const all = [...this.#map.keys()]
+			.filter((key) => key.startsWith(prefix))
+			.toSorted()
+		const start = options?.cursor ? Number.parseInt(options.cursor, 10) || 0 : 0
+		const limit = options?.limit ?? 1000
+		const page = all.slice(start, start + limit)
+		const next = start + page.length
+		const listComplete = next >= all.length
+		return {
+			keys: page.map((name) => ({ name })),
+			list_complete: listComplete,
+			cursor: listComplete ? undefined : String(next),
+		}
 	}
 }
 
@@ -140,6 +160,7 @@ export function createTestEnv(overrides: Partial<AppEnv> = {}): AppEnv {
 	return {
 		DB: createD1(sqlite),
 		RATE_LIMIT: new MemoryKv() as unknown as KVNamespace,
+		OAUTH_KV: new MemoryKv() as unknown as KVNamespace,
 		BLOBS: new MemoryR2() as unknown as R2Bucket,
 		COOKIE_SECRET: 'test-cookie-secret-at-least-32-bytes',
 		APP_BASE_URL: 'https://kody.exchange',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -50,10 +50,11 @@ export { ThreadRoom }
 
 export default {
 	fetch(request: Request, env: AppEnv, ctx: ExecutionContext) {
-		// OAuthProvider serves this URL first and defaults `resource` to the
-		// origin only. MCP clients follow RFC 9728 from WWW-Authenticate and
-		// must see `<origin>/mcp` on the root PRM, or the token audience fails
-		// and Kody stays "authenticating".
+		// OAuthProvider serves this URL first and defaults omitted `resource`
+		// to the origin. MCP clients follow RFC 9728 from WWW-Authenticate and
+		// must see `<origin>/mcp` on the root PRM. Authorize still mints a
+		// shared product audience (origin, /api, /mcp) when the client omits
+		// resource or sends the origin, so /api and /mcp both accept the token.
 		const pathname = new URL(request.url).pathname
 		if (isProtectedResourceMetadataPath(pathname)) {
 			return handleProtectedResourceMetadata(request, env)


### PR DESCRIPTION
## Bug

Kody's built-in `kody-exchange` integration at `https://kody.codes/connect/oauth?provider=kody-exchange` omits RFC 8707 `resource` (its `apiBaseUrl` is `https://kody.exchange`). Authorize was silently defaulting that omitted resource to `https://kody.exchange/mcp`.

The same access token then split across surfaces:

- `GET /mcp` → 200 (custom `resolveOAuthUser` already accepts origin, `/mcp`, and `/api`)
- `GET /api/me` and `GET /api/threads` → 401 `{ error: "invalid_token", error_description: "Token audience does not match resource server" }`
- Refresh via Kody `integration_token_refresh` → 400 `invalid_grant`

This is not a missed reconnect. It is an audience split between `/mcp` and `/api`.

## Live repro (2026-08-17)

Kent reconnected the platform Kody integration. Tokens were written at `2026-08-17T12:13:58Z`.

- `GET https://kody.exchange/mcp` → 200, user `kentcdodds`
- `GET https://kody.exchange/api/profile` and `GET https://kody.exchange/api/threads` → 401 audience mismatch
- Subsequent refresh → `invalid_grant: Invalid refresh token`

`@kentcdodds/exchange-threads` create/list use `/api` and were broken. MCP JSON-RPC on `/mcp` worked with the same Bearer token.

## Root cause

`applyDefaultResource()` in `src/oauth-authorize.ts` set `authRequest.resource = defaultMcpResource(origin)` (`https://kody.exchange/mcp`) when the client omitted `resource`.

Cloudflare `workers-oauth-provider` `apiRoute` (`/api/`) then rejected that token: an `/mcp` audience is path-aware and does not cover `/api/*`. Origin-only audiences match any path on the same origin.

Refresh of an `/mcp`-bound grant also fails when the client presents `resource=origin`, `resource=/api`, or no matching resource.

## Fix

When `resource` is omitted or is the origin (`https://kody.exchange`), mint the shared product audience:

- `https://kody.exchange`
- `https://kody.exchange/api`
- `https://kody.exchange/mcp`

That token is accepted by both `/api/*` (provider `apiRoute`) and `/mcp` (`resolveOAuthUser`).

RFC 8707 is kept:

- explicit `resource=https://kody.exchange/mcp` stays MCP-scoped (`/api` still 401s)
- explicit `resource=https://kody.exchange/api` stays API-scoped

Refresh of a shared-product grant succeeds with no `resource`, `resource=origin`, `resource=origin/api`, or `resource=origin/mcp`.

## Tests

`src/oauth.node.test.ts` now proves:

- authorize without `resource` does not mint an `/mcp`-only audience
- a token from that grant is accepted by `/api/me`, `/api/threads`, and `/mcp` through the real `OAuthProvider` worker
- authorize with explicit `resource=/mcp` still works for MCP and is rejected on `/api`
- refresh without `resource` and with origin / `/api` / `/mcp` does not return `invalid_grant`

`npm run validate` is green (format, lint, typecheck, 100 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OAuth token audiences are minted at authorize time, which is auth-critical, but behavior is narrowly scoped with explicit-resource paths preserved and broad new integration tests.
> 
> **Overview**
> Fixes an **audience split** where authorize used to default omitted RFC 8707 `resource` to **`/mcp` only**, so the same Bearer token worked on **`/mcp`** but **`/api/*`** returned `invalid_token` (and refresh often failed with `invalid_grant`).
> 
> Authorize now calls **`resolveAuthorizationResource`**: when `resource` is **omitted** or a **single origin URL** (e.g. Kody’s `kody-exchange` flow), the grant mints a **shared product audience** — origin, **`/api`**, and **`/mcp`** — so Cloudflare **`apiRoute`** and MCP both accept the token. **Explicit** `resource=/mcp` or `/api` stays path-scoped; **`OAuthAuthRequest.resource`** can be a **string or array**.
> 
> Adds **unit and end-to-end worker tests** (register → authorize → token → `/api` + `/mcp` + refresh). Test harness gets **`OAUTH_KV`** and richer in-memory KV for the real OAuth provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7bd9676f774fe0546677dcdf1dbb5abbb1da48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->