### PR TITLE
Add GET /api/profile as an alias of GET /api/me

### DIFF
--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -54,6 +54,7 @@ kody.exchange is an OAuth 2.1 authorization server (same shape as kody.codes):
 Authenticated user API (bearer access token):
 
 - `GET /api/me`
+- `GET /api/profile`
 - `GET/POST /api/threads`
 - `GET/POST /api/threads/{id}/messages`
 - `PUT /api/threads/{id}/webhook`

--- a/src/oauth.node.test.ts
+++ b/src/oauth.node.test.ts
@@ -126,6 +126,10 @@ test('unauthenticated MCP and /api return 401 with WWW-Authenticate', async () =
 	expect(apiBody.signup_url).toBe('https://kody.exchange/auth/github')
 	expect(apiBody.mcp_url).toBe('https://kody.exchange/mcp')
 	expect(apiBody.hint).toContain('not a paid upgrade')
+
+	const profile = await handleRequest(request('/api/profile'), env)
+	expect(profile.status).toBe(401)
+	expect(await profile.json()).toEqual(apiBody)
 })
 
 test('authorize redirects signed-out users to GitHub with next', async () => {
@@ -242,6 +246,31 @@ test('authorize with explicit /mcp keeps an MCP-scoped resource', async () => {
 	)
 	expect(approved.status).toBe(302)
 	expect(completed?.resource).toBe('https://kody.exchange/mcp')
+})
+
+test('authenticated GET /api/profile returns the same user payload as GET /api/me', async () => {
+	const env = createTestEnv()
+	const owner = await createSignedInUser(env)
+	env.OAUTH_USER = owner.user
+
+	const me = await handleRequest(request('/api/me'), env)
+	const profile = await handleRequest(request('/api/profile'), env)
+	expect(me.status).toBe(200)
+	expect(profile.status).toBe(200)
+	const meBody = (await me.json()) as {
+		ok: boolean
+		user: { id: string; login: string; name: string | null; plan: string }
+	}
+	expect(meBody).toEqual({
+		ok: true,
+		user: {
+			id: owner.user.id,
+			login: owner.user.login,
+			name: owner.user.name,
+			plan: owner.user.plan,
+		},
+	})
+	expect(await profile.json()).toEqual(meBody)
 })
 
 test('OAuth user API creates, lists, sends, and sets a webhook', async () => {
@@ -694,6 +723,10 @@ test('resource-less authorize token works on /api and /mcp, and refresh stays va
 	expect(apiBody.ok).toBe(true)
 	expect(apiBody.user.id).toBe(owner.user.id)
 	expect(apiBody.user.login).toBe(owner.user.login)
+
+	const profile = await bearerGet(env, '/api/profile', issued.body.access_token)
+	expect(profile.status).toBe(200)
+	expect(await profile.json()).toEqual(apiBody)
 
 	const threads = await bearerGet(env, '/api/threads', issued.body.access_token)
 	expect(threads.status).toBe(200)

--- a/src/user-api.ts
+++ b/src/user-api.ts
@@ -138,6 +138,18 @@ export async function createOwnedThread(
 	})
 }
 
+function identityJson(user: UserRow) {
+	return json({
+		ok: true,
+		user: {
+			id: user.id,
+			login: user.login,
+			name: user.name,
+			plan: user.plan,
+		},
+	})
+}
+
 export async function handleUserApi(
 	request: Request,
 	env: AppEnv,
@@ -145,16 +157,11 @@ export async function handleUserApi(
 	ctx?: ExecutionContext,
 ) {
 	const url = new URL(request.url)
-	if (url.pathname === '/api/me' && request.method === 'GET') {
-		return json({
-			ok: true,
-			user: {
-				id: user.id,
-				login: user.login,
-				name: user.name,
-				plan: user.plan,
-			},
-		})
+	if (
+		request.method === 'GET' &&
+		(url.pathname === '/api/me' || url.pathname === '/api/profile')
+	) {
+		return identityJson(user)
 	}
 
 	if (url.pathname === '/api/threads' && request.method === 'GET') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`GET /api/profile` 404s. Agents and OAuth clients treat `/api/profile` as the standard authenticated identity route after connecting. The existing identity route is `GET /api/me` (`{ ok, user: { id, login, name, plan } }`).

## What

- Add `GET /api/profile` in `handleUserApi` next to `GET /api/me`
- Same auth and JSON body, via one shared `identityJson` helper so the routes cannot drift
- Keep `GET /api/me` working (not renamed or removed)
- Document `GET /api/profile` in `docs/use/index.md` in the authenticated user API list
- No new MCP tool: `/api/me` is not mirrored as an MCP tool

Out of scope: OAuth audience work (already shipped in #36).

## Tests

- Unauthenticated `GET /api/profile` still returns 401 (same body as `/api/me`)
- Authenticated `GET /api/profile` returns the same user payload as `GET /api/me`
- Bearer OAuth access token works on both routes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d5c8615-2208-42a0-9edd-50cb452385f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d5c8615-2208-42a0-9edd-50cb452385f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the authenticated `GET /api/profile` endpoint.
  - The profile endpoint returns the same identity information as `GET /api/me`.
  - Supports both session-based and bearer-token authentication.

- **Documentation**
  - Documented the new profile endpoint in the user API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->