### PR TITLE
docs(conduct): always enable Cursor Cloud PR tools

### DIFF
--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -56,7 +56,8 @@ Do not spawn a one-agent "fleet."
 
 **PR ownership.** Every code-changing agent pushes and creates/updates its own
 PR via Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before its final
-response. Never have Kody/workflows/GitHub create the initial PR. State this in
+response. `@kentcdodds/cursor` `createAgent` always enables those tools. Never
+have Kody/workflows/GitHub create the initial PR as a substitute. State this in
 every kickoff.
 
 **Report-back (wake-ups, not polling).** End of every run — done, partial, or
@@ -125,7 +126,6 @@ export default async function main() {
 		model: 'gpt-5.6-sol',
 		repository: 'https://github.com/kentcdodds/kody-exchange',
 		ref: 'main',
-		autoCreatePR: true,
 		name: 'track-short-name',
 		prompt: '…self-contained kickoff with report-back + your conductor id…',
 	})

--- a/.agents/skills/orchestrate/SKILL.md
+++ b/.agents/skills/orchestrate/SKILL.md
@@ -52,4 +52,5 @@ falsifiable. Point at this skill.
 
 Every code-changing agent must push its branch and create or update the pull
 request with Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before
-finishing. Do not have Kody open the PR.
+finishing. `@kentcdodds/cursor` `createAgent` always enables those tools. Never
+have Kody/workflows/GitHub create the initial PR as a substitute.


### PR DESCRIPTION
Match kody's conduct/orchestrate PR-ownership wording.

`@kentcdodds/cursor` `createAgent` always enables ManagePullRequest. The spawn sketch no longer passes `autoCreatePR`.

Low-risk docs/skills only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill markdown; no runtime, auth, or application code.
> 
> **Overview**
> Updates **conduct** and **orchestrate** agent skills so PR-ownership rules match current `@kentcdodds/cursor` behavior: **`createAgent` always enables** Cursor Cloud `ManagePullRequest` tooling, and Kody/workflows/GitHub must **not** open the initial PR instead.
> 
> The **conduct** spawn example drops the obsolete **`autoCreatePR: true`** option so the sketch reflects the default API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713cd3c7c2346c18ba293eab8f3e50cea9690413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->