### PR TITLE
Correct watch-link copy and publish security.txt

### DIFF
--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -456,6 +456,8 @@ test('pricing page explains live threads and participants', async () => {
 	expect(privacyHtml).toContain('me@kentcdodds.com')
 	expect(privacyHtml).toContain('Made by Kent C. Dodds')
 	expect(privacyHtml).toContain(`href="${safetyPath}"`)
+	expect(privacyHtml).toContain('Security reports')
+	expect(privacyHtml).toContain('/.well-known/security.txt')
 	expect(privacyHtml).not.toContain('Operator:')
 
 	const terms = await handleRequest(request('/terms'), env)

--- a/src/discover.node.test.ts
+++ b/src/discover.node.test.ts
@@ -10,6 +10,8 @@ import {
 	mcpServerCardPath,
 	prefersMarkdown,
 	robotsTxt,
+	securityTxt,
+	securityTxtPath,
 	sitemapXml,
 } from '#src/discover.ts'
 import { handleRequest } from '#src/index.ts'
@@ -133,7 +135,36 @@ test('public pages negotiate Markdown and expose discovery documents', async () 
 	const env = createTestEnv()
 	const llms = await handleRequest(request(llmsTxtPath), env)
 	expect(llms.status).toBe(200)
-	expect(await llms.text()).toContain('## API')
+	const llmsBody = await llms.text()
+	expect(llmsBody).toContain('## API')
+	expect(llmsBody).toContain(securityTxtPath)
+
+	const frozen = 1_777_000_000_000
+	expect(securityTxt(origin, frozen))
+		.toBe(`Contact: mailto:support@kody.exchange
+Contact: https://github.com/kentcdodds/kody-exchange/security/advisories/new
+Expires: ${new Date(frozen + 365 * 24 * 60 * 60 * 1000).toISOString()}
+Preferred-Languages: en
+Canonical: ${origin}${securityTxtPath}
+Policy: ${origin}/safety
+`)
+
+	const security = await handleRequest(request(securityTxtPath), env)
+	expect(security.status).toBe(200)
+	expect(security.headers.get('content-type')).toMatch(/text\/plain/)
+	const securityBody = await security.text()
+	expect(securityBody).toContain('Contact: mailto:support@kody.exchange')
+	expect(securityBody).toContain(
+		'Contact: https://github.com/kentcdodds/kody-exchange/security/advisories/new',
+	)
+	expect(securityBody).toContain(`Canonical: ${origin}${securityTxtPath}`)
+	expect(securityBody).toContain(`Policy: ${origin}/safety`)
+	const expires = securityBody.match(/^Expires: (\S+)/m)?.[1]
+	expect(Date.parse(expires ?? '')).toBeGreaterThan(Date.now())
+
+	const alias = await handleRequest(request('/security.txt'), env)
+	expect(alias.status).toBe(301)
+	expect(alias.headers.get('location')).toBe(`${origin}${securityTxtPath}`)
 
 	const auth = await handleRequest(request(authMdPath), env)
 	expect(auth.status).toBe(200)

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -14,6 +14,7 @@ export const mcpServerCardPath = '/.well-known/mcp/server-card.json'
 export const apiCatalogPath = '/.well-known/api-catalog'
 export const llmsTxtPath = '/llms.txt'
 export const authMdPath = '/auth.md'
+export const securityTxtPath = '/.well-known/security.txt'
 
 export function prefersMarkdown(request: Request) {
 	const accept = request.headers.get('accept')
@@ -158,6 +159,7 @@ Guest create needs no account. MCP and \`/api/\` need a free GitHub sign-in.
 - [Auth](${loc}${authMdPath}): OAuth 2.1 and MCP
 - [Privacy](${loc}/privacy)
 - [Terms](${loc}/terms)
+- [security.txt](${loc}${securityTxtPath})
 
 ## API
 
@@ -273,7 +275,7 @@ export function pageMarkdown(pathname: string, origin: string) {
 		case '/safety':
 			return safetyMarkdown(loc)
 		case '/privacy':
-			return privacyMarkdown()
+			return privacyMarkdown(loc)
 		case '/terms':
 			return termsMarkdown()
 		case examplePath:
@@ -318,7 +320,7 @@ Content-Type: application/json
 {"purpose":"<from the human>","name":"<from the human>"}
 \`\`\`
 
-Follow \`connect_prompt\` yourself. Give the other person the exact \`join_prompt\`. Give \`view_url\` only to humans who should watch.
+Follow \`connect_prompt\` yourself. Give the other person the exact \`join_prompt\`. Give \`view_url\` only to humans who should watch. That page cannot send. It shows the guest join prompt, so treat the link as an invite until the room is full.
 
 Guest threads last ${plans.guest.retentionLabel}, hold ${plans.guest.liveAgents} participants, and ${plans.guest.messagesPerMonth} messages — one live thread per IP. Sign in with GitHub for a Free account to unlock the OAuth API and MCP.
 `
@@ -413,7 +415,7 @@ HTML version: ${origin}/safety
 `
 }
 
-function privacyMarkdown() {
+function privacyMarkdown(origin: string) {
 	return `---
 title: Privacy · kody.exchange
 description: ${siteDescription}
@@ -423,7 +425,7 @@ description: ${siteDescription}
 
 kody.exchange is operated by Kent C. Dodds. Guest threads store purpose, agent names, message bodies, and the create IP for rate limits. Signed-in accounts store GitHub profile fields and Stripe identifiers if you subscribe.
 
-We do not read message bodies to train models. We do not sell your data. Guest threads delete after 24 hours. Contact support@kody.exchange.
+We do not read message bodies to train models. We do not sell your data. Guest threads delete after 24 hours. Contact support@kody.exchange. Security reports: support@kody.exchange, [${origin}${securityTxtPath}](${origin}${securityTxtPath}), or [GitHub private vulnerability reporting](https://github.com/kentcdodds/kody-exchange/security/advisories/new).
 `
 }
 
@@ -452,6 +454,18 @@ description: Canned example: Harbor Ledger and Relay Webhooks agents pair on inv
 ${examplePurpose}
 
 This is a canned example. The room is full and has infinite retention. This page cannot send, and there is no join prompt — open your own thread from [the home page](${origin}/).
+`
+}
+
+export function securityTxt(origin: string, now = Date.now()) {
+	const loc = origin.replace(/\/$/, '')
+	const expires = new Date(now + 365 * 24 * 60 * 60 * 1000).toISOString()
+	return `Contact: mailto:support@kody.exchange
+Contact: https://github.com/kentcdodds/kody-exchange/security/advisories/new
+Expires: ${expires}
+Preferred-Languages: en
+Canonical: ${loc}${securityTxtPath}
+Policy: ${loc}/safety
 `
 }
 

--- a/src/html.ts
+++ b/src/html.ts
@@ -760,6 +760,8 @@ export function privacyPage() {
 	<p>Guest threads are deleted after 24 hours. Free account data is kept 14 days of activity, Pro 90 days. You can mark an owned thread so it never expires — it still counts against your live thread limit. You can also hard-delete a thread immediately. Expired threads, members, and messages are purged. To delete an account, email <a href="mailto:support@kody.exchange">support@kody.exchange</a>.</p>
 	<h2>Security research</h2>
 	<p>We published a closed-loop study of peer-channel exfil and what a watch link grants: <a href="${safetyPath}">Peer-channel security and privacy</a>.</p>
+	<h2>Security reports</h2>
+	<p>Email <a href="mailto:support@kody.exchange">support@kody.exchange</a>. Researchers can also use <a href="/.well-known/security.txt"><code>security.txt</code></a> or <a href="https://github.com/kentcdodds/kody-exchange/security/advisories/new">GitHub private vulnerability reporting</a>.</p>
 	<h2>Processors</h2>
 	<p>Cloudflare (Workers, D1, KV, R2). GitHub (sign-in). Stripe (Pro billing). Support mail may be read by Kent at <a href="mailto:me@kentcdodds.com">me@kentcdodds.com</a>.</p>
 	<h2>Contact</h2>

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import {
 	mcpServerCard,
 	mcpServerCardPath,
 	robotsTxt,
+	securityTxt,
+	securityTxtPath,
 	sitemapXml,
 	textResponse,
 } from '#src/discover.ts'
@@ -85,6 +87,12 @@ export async function handleRequest(
 
 	if (url.pathname === '/robots.txt') {
 		return textResponse(robotsTxt(origin), 'text/plain; charset=utf-8')
+	}
+	if (url.pathname === '/security.txt') {
+		return Response.redirect(new URL(securityTxtPath, origin).toString(), 301)
+	}
+	if (url.pathname === securityTxtPath) {
+		return textResponse(securityTxt(origin), 'text/plain; charset=utf-8')
 	}
 	if (url.pathname === '/sitemap.xml') {
 		return textResponse(sitemapXml(origin), 'application/xml; charset=utf-8')

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -74,7 +74,9 @@ test('creating a thread shows a connect prompt and a join prompt once', async ()
 	expect(html).toContain('1 of 3')
 	expect(html).toContain('shown once')
 	expect(html).toContain('Open the read-only chat')
+	expect(html).toContain('treat the link as an invite until the room is full')
 	expect(html).toContain('/t/')
+	expect(html).not.toContain('cannot send messages or join agents')
 	expect(html).not.toContain("What's this thread for?")
 
 	const again = await handleRequest(

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -594,7 +594,7 @@ function threadFlashHtml(flash: ThreadFlash) {
 			<li>Paste the first into the agent you already use. It is already in the thread.</li>
 			<li>Send the second to the other person so their agent can join.</li>
 		</ol>
-		<p><a href="${escapeHtml(flash.viewUrl)}">Open the read-only chat</a> — share this link with humans who should watch. It cannot send messages or join agents.</p>
+		<p><a href="${escapeHtml(flash.viewUrl)}">Open the read-only chat</a> — share this link only with humans who should watch. The page cannot send. It shows the guest join prompt, so treat the link as an invite until the room is full.</p>
 	</div>
 	${promptCard({
 		id: 'connect-prompt',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Pre-announce leftovers that this repo can fix without touching kody.codes / kody.video / kentcdodds.com:

- After creating a thread, `/account` said the watch link “cannot send messages or join agents.” That contradicts `/safety`: the browser page cannot send, but it always shows the guest join prompt, so the link is an invite until the room is full.
- `/.well-known/security.txt` was 404.
- The GitHub about text still said “HTTP mailbox…” (updated on the repo as Kent; not in this diff).
- HSTS sent `preload` while the domain was not on the list (submitted; status is `pending`; header unchanged).

## What

- Account flash (and markdown homepage) now match `/safety` and the homepage prompt: page cannot send; treat `view_url` as an invite until seats fill.
- RFC 9116 `security.txt` at `/.well-known/security.txt`, `301` from `/security.txt`, listed in `llms.txt`. Contacts: `support@kody.exchange` and GitHub private vulnerability reporting (enabled on the repo). Policy: `/safety`.
- Privacy HTML + markdown add a Security reports section.

Already done outside this PR (as Kent):

- Repo description matches the site lede; topics: `agents`, `mcp`, `oauth`, `cloudflare-workers`, `typescript`.
- Private vulnerability reporting enabled.
- `kody.exchange` submitted to the HSTS preload list (`pending`).
- Stripe payment link `https://buy.stripe.com/7sY7sMfxO6zJa1Ubq22Ry09` returns 200 (did not complete a purchase).
- Cloudflare MX/SPF for `support@kody.exchange` is present. Inbox delivery was not end-to-end tested.

Not in this PR (per Kent): family-site cross-links on kody.codes / kody.video / kentcdodds.com.

## Test plan

- [x] Unit tests for the flash copy, `security.txt` fields, `/security.txt` redirect, and Privacy “Security reports”
- [x] `npm run validate` — 24 files, 117 tests passed

## Risk

**Low.** Copy and a well-known text file. No auth, billing, or data-model change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b855f080-0801-4c72-bc4c-9bc03c4881fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b855f080-0801-4c72-bc4c-9bc03c4881fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

