### PR TITLE
Hide thread view copy prompts inside a details element

### DIFF
--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -252,7 +252,7 @@ test('guest thread: create, join, send, poll, and health', async () => {
 		),
 	)
 	expect(viewHtml).toMatch(/data-mine[\s\S]*on my way/)
-	expect(viewHtml).toContain('<details class="thread-prompts">')
+	expect(viewHtml).toContain('class="thread-prompts" data-thread-prompts')
 	expect(viewHtml).toContain('<summary>Copy guest prompt</summary>')
 	expect(viewHtml).toContain('>Guest<')
 	expect(viewHtml).toContain('Copy prompt')

--- a/src/api.node.test.ts
+++ b/src/api.node.test.ts
@@ -252,6 +252,8 @@ test('guest thread: create, join, send, poll, and health', async () => {
 		),
 	)
 	expect(viewHtml).toMatch(/data-mine[\s\S]*on my way/)
+	expect(viewHtml).toContain('<details class="thread-prompts">')
+	expect(viewHtml).toContain('<summary>Copy guest prompt</summary>')
 	expect(viewHtml).toContain('>Guest<')
 	expect(viewHtml).toContain('Copy prompt')
 	expect(viewHtml).toContain('Join this kody.exchange thread')

--- a/src/example-thread.node.test.ts
+++ b/src/example-thread.node.test.ts
@@ -80,6 +80,7 @@ test('example page is the view UI without join capabilities', async () => {
 	expect(html).toContain('data-mine')
 	expect(html).not.toContain('data-poll=')
 	expect(html).not.toContain('connectLive()')
+	expect(html).not.toContain('class="thread-prompts"')
 	expect(html).not.toContain('>Host<')
 	expect(html).not.toContain('>Guest<')
 	expect(html).not.toContain('kx_join_')

--- a/src/html.ts
+++ b/src/html.ts
@@ -232,6 +232,10 @@ form.card ol { margin: .4rem 0 1rem; }
 .card li { margin: .25rem 0; }
 main.thread-page { width: min(720px, calc(100% - 2rem)); }
 .thread-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; flex-wrap: wrap; }
+.thread-prompts { margin: 1.2rem 0; }
+.thread-prompts > summary { cursor: pointer; font-family: "IBM Plex Mono", monospace; font-size: .85rem; color: var(--muted); }
+.thread-prompts[open] > summary { margin-bottom: .4rem; color: var(--ink); }
+.thread-prompts .card { margin: .75rem 0 0; }
 .chat { display: flex; flex-direction: column; gap: .75rem; margin: 1.2rem 0 2rem; min-height: 12rem; max-height: min(70vh, 44rem); overflow-y: auto; overflow-anchor: none; padding: .15rem .25rem .15rem 0; }
 .bubble { align-self: flex-start; max-width: min(34rem, 88%); background: color-mix(in srgb, var(--agent, var(--leaf)) 10%, var(--card)); border: 1px solid var(--line); border-left: 4px solid var(--agent, var(--leaf)); border-radius: 0 16px 16px 0; padding: .75rem 1rem; }
 .bubble[data-mine] { align-self: flex-end; border-left: 1px solid var(--line); border-right: 4px solid var(--agent, var(--leaf)); border-radius: 16px 0 0 16px; }
@@ -557,6 +561,35 @@ export function threadViewPage(input: {
 					)
 					.join('')
 	const livePath = input.pollPath.replace(/\/messages$/, '/live')
+	const promptCards = archived
+		? []
+		: [
+				input.hostPrompt
+					? promptCard({
+							id: 'host-prompt',
+							title: 'Host',
+							hint: 'Already in the thread. Paste this into that agent — it must not join again or share the bearer.',
+							prompt: input.hostPrompt,
+						})
+					: '',
+				input.guestPrompt
+					? promptCard({
+							id: 'guest-prompt',
+							title: 'Guest',
+							hint: 'Paste this into an agent that still needs to join. It should ask for a display name, then use the token from the join response — not the join_token — as the bearer.',
+							prompt: input.guestPrompt,
+						})
+					: '',
+			].filter(Boolean)
+	const prompts =
+		promptCards.length > 0
+			? `<details class="thread-prompts">
+		<summary>${escapeHtml(
+			input.hostPrompt ? 'Copy host or guest prompts' : 'Copy guest prompt',
+		)}</summary>
+		${promptCards.join('')}
+	</details>`
+			: ''
 	return `
 	<div class="thread-head">
 		<div>
@@ -583,30 +616,7 @@ export function threadViewPage(input: {
 		<button type="button" data-copy-url>Copy watch link</button>
 		<span class="tiny" data-copied hidden>Copied.</span>
 	</div>
-	${
-		archived
-			? ''
-			: `${
-					input.hostPrompt
-						? promptCard({
-								id: 'host-prompt',
-								title: 'Host',
-								hint: 'Already in the thread. Paste this into that agent — it must not join again or share the bearer.',
-								prompt: input.hostPrompt,
-							})
-						: ''
-				}
-	${
-		input.guestPrompt
-			? promptCard({
-					id: 'guest-prompt',
-					title: 'Guest',
-					hint: 'Paste this into an agent that still needs to join. It should ask for a display name, then use the token from the join response — not the join_token — as the bearer.',
-					prompt: input.guestPrompt,
-				})
-			: ''
-	}`
-	}
+	${prompts}
 	<div class="chat" data-chat${live ? ` data-poll="${escapeHtml(input.pollPath)}" data-live="${escapeHtml(livePath)}"` : ''} data-after="${escapeHtml(lastId)}" data-viewer="${escapeHtml(input.viewer)}" data-host-agent="${escapeHtml(input.hostAgentId ?? '')}">${chat}</div>
 	${live ? threadViewLiveScript() : ''}
 	${copyPromptScript()}

--- a/src/html.ts
+++ b/src/html.ts
@@ -26,7 +26,11 @@ import {
 	isMineBubble,
 	type ThreadViewViewer,
 } from '#src/thread-view-chat.ts'
-import { threadViewLiveScript } from '#src/thread-view-live.ts'
+import {
+	THREAD_VIEW_ARCHIVED_INTRO,
+	THREAD_VIEW_ARCHIVED_STAMP,
+	threadViewLiveScript,
+} from '#src/thread-view-live.ts'
 import { isThreadArchived, type ThreadRow, type UserRow } from '#src/threads.ts'
 
 export { siteDescription }
@@ -543,11 +547,12 @@ export function threadViewPage(input: {
 			? null
 			: input.thread.expires_at
 	const expiresAttr = expiresAt === null ? 'infinite' : String(expiresAt)
-	const stamp = input.stamp ?? (archived ? 'Archived' : 'Read-only')
+	const stamp =
+		input.stamp ?? (archived ? THREAD_VIEW_ARCHIVED_STAMP : 'Read-only')
 	const intro =
 		input.intro ??
 		(archived
-			? 'This thread is archived. It is read-only. Agents can no longer send or poll, and this page does not subscribe for updates.'
+			? THREAD_VIEW_ARCHIVED_INTRO
 			: `This page cannot send messages. Agents write over HTTP. ${input.hostPrompt ? 'Copy a prompt for the host or a guest.' : 'Copy the guest prompt to join an agent.'}`)
 	const chat =
 		input.messages.length === 0
@@ -583,7 +588,7 @@ export function threadViewPage(input: {
 			].filter(Boolean)
 	const prompts =
 		promptCards.length > 0
-			? `<details class="thread-prompts">
+			? `<details class="thread-prompts" data-thread-prompts>
 		<summary>${escapeHtml(
 			input.hostPrompt ? 'Copy host or guest prompts' : 'Copy guest prompt',
 		)}</summary>
@@ -593,7 +598,7 @@ export function threadViewPage(input: {
 	return `
 	<div class="thread-head">
 		<div>
-			<p class="stamp">${escapeHtml(stamp)}</p>
+			<p class="stamp" data-stamp>${escapeHtml(stamp)}</p>
 			<h1>${escapeHtml(purpose)}</h1>
 			<p class="tiny" data-roster data-seats="${escapeHtml(String(input.seats))}" data-expires="${escapeHtml(expiresAttr)}">${escapeHtml(
 				rosterLine({
@@ -605,13 +610,13 @@ export function threadViewPage(input: {
 		</div>
 		${
 			live
-				? `<p class="live" data-live><span class="live-dot" aria-hidden="true"></span> <span data-live-label>Updating every few seconds</span></p>`
+				? `<p class="live" data-live-status><span class="live-dot" aria-hidden="true"></span> <span data-live-label>Updating every few seconds</span></p>`
 				: archived
 					? ''
 					: `<p class="live">Canned example</p>`
 		}
 	</div>
-	<p>${escapeHtml(intro)}</p>
+	<p data-intro>${escapeHtml(intro)}</p>
 	<div class="row">
 		<button type="button" data-copy-url>Copy watch link</button>
 		<span class="tiny" data-copied hidden>Copied.</span>

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -274,6 +274,9 @@ test('thread view shows host prompt only to the signed-in owner', async () => {
 			env,
 		)
 	).text()
+	expect(ownerView).toContain('<details class="thread-prompts">')
+	expect(ownerView).toContain('<summary>Copy host or guest prompts</summary>')
+	expect(ownerView).not.toMatch(/<details class="thread-prompts"[^>]*\bopen\b/)
 	expect(ownerView).toContain('>Host<')
 	expect(ownerView).toContain('>Guest<')
 	expect(ownerView).toContain(
@@ -285,6 +288,9 @@ test('thread view shows host prompt only to the signed-in owner', async () => {
 	const publicView = await (
 		await handleRequest(request(viewPath ?? '/'), env)
 	).text()
+	expect(publicView).toContain('<details class="thread-prompts">')
+	expect(publicView).toContain('<summary>Copy guest prompt</summary>')
+	expect(publicView).not.toMatch(/<details class="thread-prompts"[^>]*\bopen\b/)
 	expect(publicView).toContain('>Guest<')
 	expect(publicView).toContain('kx_join_')
 	expect(publicView).not.toContain('>Host<')

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -274,7 +274,9 @@ test('thread view shows host prompt only to the signed-in owner', async () => {
 			env,
 		)
 	).text()
-	expect(ownerView).toContain('<details class="thread-prompts">')
+	expect(ownerView).toContain('data-stamp')
+	expect(ownerView).toContain('data-intro')
+	expect(ownerView).toContain('class="thread-prompts" data-thread-prompts')
 	expect(ownerView).toContain('<summary>Copy host or guest prompts</summary>')
 	expect(ownerView).not.toMatch(/<details class="thread-prompts"[^>]*\bopen\b/)
 	expect(ownerView).toContain('>Host<')
@@ -288,7 +290,7 @@ test('thread view shows host prompt only to the signed-in owner', async () => {
 	const publicView = await (
 		await handleRequest(request(viewPath ?? '/'), env)
 	).text()
-	expect(publicView).toContain('<details class="thread-prompts">')
+	expect(publicView).toContain('class="thread-prompts" data-thread-prompts')
 	expect(publicView).toContain('<summary>Copy guest prompt</summary>')
 	expect(publicView).not.toMatch(/<details class="thread-prompts"[^>]*\bopen\b/)
 	expect(publicView).toContain('>Guest<')

--- a/src/thread-room.node.test.ts
+++ b/src/thread-room.node.test.ts
@@ -39,10 +39,13 @@ test('ThreadRoom broadcasts JSON to attached sockets', async () => {
 })
 
 test('ThreadRoom closes attached sockets on /close', async () => {
+	const sent: Array<string> = []
 	const closed: Array<{ code: number; reason: string }> = []
 	const sockets = [
 		{
-			send() {},
+			send(data: string) {
+				sent.push(data)
+			},
 			close(code: number, reason: string) {
 				closed.push({ code, reason })
 			},
@@ -59,6 +62,7 @@ test('ThreadRoom closes attached sockets on /close', async () => {
 		new Request('https://thread-room/close', { method: 'POST' }),
 	)
 	expect(response.status).toBe(204)
+	expect(sent).toEqual(['{"ok":true,"archived":true,"messages":[]}'])
 	expect(closed).toEqual([{ code: 1000, reason: 'archived' }])
 })
 

--- a/src/thread-room.ts
+++ b/src/thread-room.ts
@@ -1,5 +1,9 @@
 import { type AppEnv } from '#src/env.ts'
 import { type MessageEnvelope } from '#src/envelope.ts'
+import {
+	THREAD_VIEW_ARCHIVED_CLOSE_REASON,
+	threadViewArchivedPayload,
+} from '#src/thread-view-live.ts'
 import { type ThreadMemberView } from '#src/threads.ts'
 
 export class ThreadRoom {
@@ -16,9 +20,11 @@ export class ThreadRoom {
 		}
 		if (request.method === 'POST') {
 			if (new URL(request.url).pathname === '/close') {
+				const payload = JSON.stringify(threadViewArchivedPayload())
 				for (const socket of this.ctx.getWebSockets()) {
 					try {
-						socket.close(1000, 'archived')
+						socket.send(payload)
+						socket.close(1000, THREAD_VIEW_ARCHIVED_CLOSE_REASON)
 					} catch {
 						// Drop dead sockets; hibernation cleanup will finish them.
 					}

--- a/src/thread-view-live.node.test.ts
+++ b/src/thread-view-live.node.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from 'vitest'
 import {
+	applyArchivedThreadView,
 	isPinnedToBottom,
 	nextPollDelayMs,
+	THREAD_VIEW_ARCHIVED_CLOSE_REASON,
+	THREAD_VIEW_ARCHIVED_INTRO,
+	THREAD_VIEW_ARCHIVED_STAMP,
+	threadViewArchivedPayload,
 	threadViewLiveScript,
 	VIEW_POLL_DEFAULT_SECONDS,
 	VIEW_POLL_NEAR_BOTTOM_PX,
@@ -73,9 +78,79 @@ test('live script prefers a socket and pins when already at the bottom', () => {
 	expect(script).not.toContain('if (socketOpen) return')
 	expect(script).not.toContain('window.setTimeout(tick, 5000)')
 	expect(script).toContain('response.status === 409')
-	expect(script).toContain("stopLive('Archived')")
+	expect(script).toContain('applyArchivedView()')
+	expect(script).toContain('data.archived')
+	expect(script).toContain(`event.reason === ${JSON.stringify(THREAD_VIEW_ARCHIVED_CLOSE_REASON)}`)
+	expect(script).toContain(JSON.stringify(THREAD_VIEW_ARCHIVED_STAMP))
+	expect(script).toContain(JSON.stringify(THREAD_VIEW_ARCHIVED_INTRO))
+	expect(script).toContain('[data-thread-prompts]')
+	expect(script).toContain('[data-live-status]')
+	expect(script).toContain("removeAttribute('data-poll')")
+	expect(script).toContain("removeAttribute('data-live')")
 	expect(script).toContain('stopped = true')
 	expect(script).toContain('if (stopped) return')
 	expect(script).toContain('liveSocket?.close()')
 	expect(script).toContain('if (stopped || (!pollPath && !livePath)) return')
+})
+
+test('applyArchivedThreadView matches a freshly loaded archived page', () => {
+	const stamp = { textContent: 'Read-only', remove() {}, removeAttribute() {} }
+	const intro = {
+		textContent: 'Copy the guest prompt to join an agent.',
+		remove() {},
+		removeAttribute() {},
+	}
+	const removed: Array<string> = []
+	const attrs: Array<string> = []
+	const nodes = new Map([
+		['[data-stamp]', stamp],
+		['[data-intro]', intro],
+		[
+			'[data-thread-prompts]',
+			{
+				textContent: null,
+				remove() {
+					removed.push('prompts')
+				},
+				removeAttribute() {},
+			},
+		],
+		[
+			'[data-live-status]',
+			{
+				textContent: 'Live',
+				remove() {
+					removed.push('live')
+				},
+				removeAttribute() {},
+			},
+		],
+		[
+			'[data-chat]',
+			{
+				textContent: null,
+				remove() {},
+				removeAttribute(name: string) {
+					attrs.push(name)
+				},
+			},
+		],
+	])
+	applyArchivedThreadView({
+		querySelector(selector: string) {
+			return nodes.get(selector) ?? null
+		},
+	})
+	expect(stamp.textContent).toBe(THREAD_VIEW_ARCHIVED_STAMP)
+	expect(intro.textContent).toBe(THREAD_VIEW_ARCHIVED_INTRO)
+	expect(removed).toEqual(['prompts', 'live'])
+	expect(attrs).toEqual(['data-poll', 'data-live'])
+})
+
+test('threadViewArchivedPayload tells the watch page to freeze', () => {
+	expect(threadViewArchivedPayload()).toEqual({
+		ok: true,
+		archived: true,
+		messages: [],
+	})
 })

--- a/src/thread-view-live.node.test.ts
+++ b/src/thread-view-live.node.test.ts
@@ -10,6 +10,7 @@ import {
 	threadViewLiveScript,
 	VIEW_POLL_DEFAULT_SECONDS,
 	VIEW_POLL_NEAR_BOTTOM_PX,
+	type ArchivedViewRoot,
 } from '#src/thread-view-live.ts'
 
 test('isPinnedToBottom is true at or near the bottom', () => {
@@ -104,7 +105,8 @@ test('applyArchivedThreadView matches a freshly loaded archived page', () => {
 	}
 	const removed: Array<string> = []
 	const attrs: Array<string> = []
-	const nodes = new Map([
+	type ViewNode = NonNullable<ReturnType<ArchivedViewRoot['querySelector']>>
+	const nodes = new Map<string, ViewNode>([
 		['[data-stamp]', stamp],
 		['[data-intro]', intro],
 		[

--- a/src/thread-view-live.node.test.ts
+++ b/src/thread-view-live.node.test.ts
@@ -80,7 +80,9 @@ test('live script prefers a socket and pins when already at the bottom', () => {
 	expect(script).toContain('response.status === 409')
 	expect(script).toContain('applyArchivedView()')
 	expect(script).toContain('data.archived')
-	expect(script).toContain(`event.reason === ${JSON.stringify(THREAD_VIEW_ARCHIVED_CLOSE_REASON)}`)
+	expect(script).toContain(
+		`event.reason === ${JSON.stringify(THREAD_VIEW_ARCHIVED_CLOSE_REASON)}`,
+	)
 	expect(script).toContain(JSON.stringify(THREAD_VIEW_ARCHIVED_STAMP))
 	expect(script).toContain(JSON.stringify(THREAD_VIEW_ARCHIVED_INTRO))
 	expect(script).toContain('[data-thread-prompts]')

--- a/src/thread-view-live.ts
+++ b/src/thread-view-live.ts
@@ -2,6 +2,38 @@ import { AGENT_ACCENT_COUNT } from '#src/thread-view-chat.ts'
 
 export const VIEW_POLL_NEAR_BOTTOM_PX = 48
 export const VIEW_POLL_DEFAULT_SECONDS = 5
+export const THREAD_VIEW_ARCHIVED_STAMP = 'Archived'
+export const THREAD_VIEW_ARCHIVED_INTRO =
+	'This thread is archived. It is read-only. Agents can no longer send or poll, and this page does not subscribe for updates.'
+export const THREAD_VIEW_ARCHIVED_CLOSE_REASON = 'archived'
+
+export type ArchivedViewRoot = {
+	querySelector(selectors: string): {
+		textContent: string | null
+		remove(): void
+		removeAttribute(name: string): void
+	} | null
+}
+
+export function applyArchivedThreadView(root: ArchivedViewRoot) {
+	const stamp = root.querySelector('[data-stamp]')
+	if (stamp) stamp.textContent = THREAD_VIEW_ARCHIVED_STAMP
+	const intro = root.querySelector('[data-intro]')
+	if (intro) intro.textContent = THREAD_VIEW_ARCHIVED_INTRO
+	root.querySelector('[data-thread-prompts]')?.remove()
+	root.querySelector('[data-live-status]')?.remove()
+	const chat = root.querySelector('[data-chat]')
+	chat?.removeAttribute('data-poll')
+	chat?.removeAttribute('data-live')
+}
+
+export function threadViewArchivedPayload() {
+	return {
+		ok: true,
+		archived: true,
+		messages: [] as Array<never>,
+	}
+}
 
 export type ScrollMetrics = {
 	scrollTop: number
@@ -146,14 +178,24 @@ export function threadViewLiveScript() {
 			}
 			if (pinned) pinToBottom()
 		}
-		function stopLive(label) {
+		function stopLive() {
 			stopped = true
 			socketOpen = false
 			window.clearTimeout(pollTimer)
 			pollGeneration += 1
 			try { liveSocket?.close() } catch {}
 			liveSocket = null
-			setLiveLabel(label)
+		}
+		function applyArchivedView() {
+			stopLive()
+			const stamp = document.querySelector('[data-stamp]')
+			if (stamp) stamp.textContent = ${JSON.stringify(THREAD_VIEW_ARCHIVED_STAMP)}
+			const intro = document.querySelector('[data-intro]')
+			if (intro) intro.textContent = ${JSON.stringify(THREAD_VIEW_ARCHIVED_INTRO)}
+			document.querySelector('[data-thread-prompts]')?.remove()
+			document.querySelector('[data-live-status]')?.remove()
+			chat?.removeAttribute('data-poll')
+			chat?.removeAttribute('data-live')
 		}
 		async function tick() {
 			if (stopped || !pollPath) return
@@ -164,7 +206,7 @@ export function threadViewLiveScript() {
 				const retryAfterHeader = response.headers.get('retry-after')
 				if (generation !== pollGeneration) return
 				if (response.status === 409) {
-					stopLive('Archived')
+					applyArchivedView()
 					return
 				}
 				if (response.ok) {
@@ -211,13 +253,21 @@ export function threadViewLiveScript() {
 				if (stopped) return
 				try {
 					const data = JSON.parse(String(event.data))
+					if (data.archived) {
+						applyArchivedView()
+						return
+					}
 					appendMessages(data.messages ?? [])
 					if (data.members) updateRoster(data.members)
 				} catch {}
 			})
-			liveSocket.addEventListener('close', () => {
+			liveSocket.addEventListener('close', (event) => {
 				socketOpen = false
 				if (stopped) return
+				if (event.reason === ${JSON.stringify(THREAD_VIEW_ARCHIVED_CLOSE_REASON)}) {
+					applyArchivedView()
+					return
+				}
 				setLiveLabel('Updating every few seconds')
 				void tick()
 			})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The host and guest prompt cards on `/t/{kx_view_…}` take a lot of vertical space before the chat. This keeps the same copy buttons and tokens, but hides those cards behind a closed native `<details>` so the conversation is visible first.

When a host archives a live thread, the watch page now applies the archived state in place — no manual refresh:

- Stamp switches to **Archived**
- Intro matches a freshly loaded archived page
- Prompt details are removed
- Live indicator and poll/socket hooks stop

The room sends `{ archived: true }` and closes the socket with reason `archived`. Poll `409` is still a fallback.

- Owner sees **Copy host or guest prompts**
- Everyone else sees **Copy guest prompt**
- Example and archived views still omit prompts entirely

`npm run validate` is green locally (25 files / 127 tests). Tests assert the details wrapper is closed by default, prompt content is unchanged, and archive updates the same DOM the archived HTML uses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3462804-7df1-4834-8278-fd0938cd39dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3462804-7df1-4834-8278-fd0938cd39dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

