### PR TITLE
Embed the kody.exchange demo video on the homepage

### DIFF
--- a/public/lite-yt-embed.css
+++ b/public/lite-yt-embed.css
@@ -1,0 +1,104 @@
+/* Vendored lite-youtube-embed v0.3.4 — https://github.com/paulirish/lite-youtube-embed
+   Copyright 2019 Paul Irish. Apache License 2.0. http://www.apache.org/licenses/LICENSE-2.0 */
+lite-youtube {
+	background-color: #000;
+	position: relative;
+	display: block;
+	contain: content;
+	background-position: center center;
+	background-size: cover;
+	cursor: pointer;
+	max-width: 720px;
+}
+
+/* gradient */
+lite-youtube::before {
+	content: attr(data-title);
+	display: block;
+	position: absolute;
+	top: 0;
+	/* Pixel-perfect port of YT's gradient PNG, using https://github.com/bluesmoon/pngtocss plus optimizations */
+	background-image: linear-gradient(
+		180deg,
+		rgb(0 0 0 / 67%) 0%,
+		rgb(0 0 0 / 54%) 14%,
+		rgb(0 0 0 / 15%) 54%,
+		rgb(0 0 0 / 5%) 72%,
+		rgb(0 0 0 / 0%) 94%
+	);
+	height: 99px;
+	width: 100%;
+	font-family: 'YouTube Noto', Roboto, Arial, Helvetica, sans-serif;
+	color: hsl(0deg 0% 93.33%);
+	text-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
+	font-size: 18px;
+	padding: 25px 20px;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	box-sizing: border-box;
+}
+
+lite-youtube:hover::before {
+	color: white;
+}
+
+/* responsive iframe with a 16:9 aspect ratio
+    thanks https://css-tricks.com/responsive-iframes/
+*/
+lite-youtube::after {
+	content: '';
+	display: block;
+	padding-bottom: calc(100% / (16 / 9));
+}
+lite-youtube > iframe {
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+	border: 0;
+}
+
+/* play button */
+lite-youtube > .lyt-playbtn {
+	display: block;
+	/* Make the button element cover the whole area for a large hover/click target… */
+	width: 100%;
+	height: 100%;
+	/* …but visually it's still the same size */
+	background: no-repeat center/68px 48px;
+	/* YT's actual play button svg */
+	background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
+	position: absolute;
+	cursor: pointer;
+	z-index: 1;
+	filter: grayscale(100%);
+	transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
+	border: 0;
+}
+
+lite-youtube:hover > .lyt-playbtn,
+lite-youtube .lyt-playbtn:focus {
+	filter: none;
+}
+
+/* Post-click styles */
+lite-youtube.lyt-activated {
+	cursor: unset;
+}
+lite-youtube.lyt-activated::before,
+lite-youtube.lyt-activated > .lyt-playbtn {
+	opacity: 0;
+	pointer-events: none;
+}
+
+.lyt-visually-hidden {
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}

--- a/public/lite-yt-embed.js
+++ b/public/lite-yt-embed.js
@@ -1,0 +1,257 @@
+/**
+ * Vendored lite-youtube-embed v0.3.4 — https://github.com/paulirish/lite-youtube-embed
+ * Copyright 2019 Paul Irish. Apache License 2.0. http://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * A lightweight youtube embed. Still should feel the same to the user, just MUCH faster to initialize and paint.
+ *
+ * Thx to these as the inspiration
+ *   https://storage.googleapis.com/amp-vs-non-amp/youtube-lazy.html
+ *   https://autoplay-youtube-player.glitch.me/
+ *
+ * Once built it, I also found these:
+ *   https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube (👍👍)
+ *   https://github.com/Daugilas/lazyYT
+ *   https://github.com/vb/lazyframe
+ */
+class LiteYTEmbed extends HTMLElement {
+	connectedCallback() {
+		this.videoId = this.getAttribute('videoid')
+
+		let playBtnEl = this.querySelector('.lyt-playbtn,.lty-playbtn')
+		// A label for the button takes priority over a [playlabel] attribute on the custom-element
+		this.playLabel =
+			(playBtnEl && playBtnEl.textContent.trim()) ||
+			this.getAttribute('playlabel') ||
+			'Play'
+
+		this.dataset.title = this.getAttribute('title') || ''
+
+		/**
+		 * Lo, the youtube poster image!  (aka the thumbnail, image placeholder, etc)
+		 *
+		 * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
+		 */
+		if (!this.style.backgroundImage) {
+			this.style.backgroundImage = `url("https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg")`
+			this.upgradePosterImage()
+		}
+
+		// Set up play button, and its visually hidden label
+		if (!playBtnEl) {
+			playBtnEl = document.createElement('button')
+			playBtnEl.type = 'button'
+			// Include the mispelled 'lty-' in case it's still being used. https://github.com/paulirish/lite-youtube-embed/issues/65
+			playBtnEl.classList.add('lyt-playbtn', 'lty-playbtn')
+			this.append(playBtnEl)
+		}
+		if (!playBtnEl.textContent) {
+			const playBtnLabelEl = document.createElement('span')
+			playBtnLabelEl.className = 'lyt-visually-hidden'
+			playBtnLabelEl.textContent = this.playLabel
+			playBtnEl.append(playBtnLabelEl)
+		}
+
+		this.addNoscriptIframe()
+
+		// for the PE pattern, change anchor's semantics to button
+		if (playBtnEl.nodeName === 'A') {
+			playBtnEl.removeAttribute('href')
+			playBtnEl.setAttribute('tabindex', '0')
+			playBtnEl.setAttribute('role', 'button')
+			// fake button needs keyboard help
+			playBtnEl.addEventListener('keydown', (e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault()
+					this.activate()
+				}
+			})
+		}
+
+		// On hover (or tap), warm up the TCP connections we're (likely) about to use.
+		this.addEventListener('pointerover', LiteYTEmbed.warmConnections, {
+			once: true,
+		})
+		this.addEventListener('focusin', LiteYTEmbed.warmConnections, {
+			once: true,
+		})
+
+		// Once the user clicks, add the real iframe and drop our play button
+		// TODO: In the future we could be like amp-youtube and silently swap in the iframe during idle time
+		//   We'd want to only do this for in-viewport or near-viewport ones: https://github.com/ampproject/amphtml/pull/5003
+		this.addEventListener('click', this.activate)
+
+		// Chrome & Edge desktop have no problem with the basic YouTube Embed with ?autoplay=1
+		// However Safari desktop and most/all mobile browsers do not successfully track the user gesture of clicking through the creation/loading of the iframe,
+		// so they don't autoplay automatically. Instead we must load an additional 2 sequential JS files (1KB + 165KB) (un-br) for the YT Player API
+		// TODO: Try loading the the YT API in parallel with our iframe and then attaching/playing it. #82
+		this.needsYTApi =
+			this.hasAttribute('js-api') ||
+			navigator.vendor.includes('Apple') ||
+			navigator.userAgent.includes('Mobi')
+	}
+
+	/**
+	 * Add a <link rel={preload | preconnect} ...> to the head
+	 */
+	static addPrefetch(kind, url, as) {
+		const linkEl = document.createElement('link')
+		linkEl.rel = kind
+		linkEl.href = url
+		if (as) {
+			linkEl.as = as
+		}
+		document.head.append(linkEl)
+	}
+
+	/**
+	 * Begin pre-connecting to warm up the iframe load
+	 * Since the embed's network requests load within its iframe,
+	 *   preload/prefetch'ing them outside the iframe will only cause double-downloads.
+	 * So, the best we can do is warm up a few connections to origins that are in the critical path.
+	 *
+	 * Maybe `<link rel=preload as=document>` would work, but it's unsupported: http://crbug.com/593267
+	 * But TBH, I don't think it'll happen soon with Site Isolation and split caches adding serious complexity.
+	 */
+	static warmConnections() {
+		if (LiteYTEmbed.preconnected) return
+
+		// The iframe document and most of its subresources come right off youtube.com
+		LiteYTEmbed.addPrefetch('preconnect', 'https://www.youtube-nocookie.com')
+		// The botguard script is fetched off from google.com
+		LiteYTEmbed.addPrefetch('preconnect', 'https://www.google.com')
+
+		// Not certain if these ad related domains are in the critical path. Could verify with domain-specific throttling.
+		LiteYTEmbed.addPrefetch('preconnect', 'https://googleads.g.doubleclick.net')
+		LiteYTEmbed.addPrefetch('preconnect', 'https://static.doubleclick.net')
+
+		LiteYTEmbed.preconnected = true
+	}
+
+	fetchYTPlayerApi() {
+		if (window.YT || (window.YT && window.YT.Player)) return
+
+		this.ytApiPromise = new Promise((res, rej) => {
+			var el = document.createElement('script')
+			el.src = 'https://www.youtube.com/iframe_api'
+			el.async = true
+			el.onload = (_) => {
+				YT.ready(res)
+			}
+			el.onerror = rej
+			this.append(el)
+		})
+	}
+
+	/** Return the YT Player API instance. (Public L-YT-E API) */
+	async getYTPlayer() {
+		if (!this.playerPromise) {
+			await this.activate()
+		}
+
+		return this.playerPromise
+	}
+
+	async addYTPlayerIframe() {
+		this.fetchYTPlayerApi()
+		await this.ytApiPromise
+
+		const videoPlaceholderEl = document.createElement('div')
+		this.append(videoPlaceholderEl)
+
+		const paramsObj = Object.fromEntries(this.getParams().entries())
+
+		this.playerPromise = new Promise((resolve) => {
+			let player = new YT.Player(videoPlaceholderEl, {
+				width: '100%',
+				videoId: this.videoId,
+				playerVars: paramsObj,
+				events: {
+					onReady: (event) => {
+						event.target.playVideo()
+						resolve(player)
+					},
+				},
+			})
+		})
+	}
+
+	// Add the iframe within <noscript> for indexability discoverability. See https://github.com/paulirish/lite-youtube-embed/issues/105
+	addNoscriptIframe() {
+		const iframeEl = this.createBasicIframe()
+		const noscriptEl = document.createElement('noscript')
+		// Appending into noscript isn't equivalant for mysterious reasons: https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element
+		noscriptEl.innerHTML = iframeEl.outerHTML
+		this.append(noscriptEl)
+	}
+
+	getParams() {
+		const params = new URLSearchParams(this.getAttribute('params') || [])
+		params.append('autoplay', '1')
+		params.append('playsinline', '1')
+		return params
+	}
+
+	async activate() {
+		if (this.classList.contains('lyt-activated')) return
+		this.classList.add('lyt-activated')
+
+		if (this.needsYTApi) {
+			return this.addYTPlayerIframe(this.getParams())
+		}
+
+		const iframeEl = this.createBasicIframe()
+		this.append(iframeEl)
+
+		// Set focus for a11y
+		iframeEl.focus()
+	}
+
+	createBasicIframe() {
+		const iframeEl = document.createElement('iframe')
+		iframeEl.width = 560
+		iframeEl.height = 315
+		// No encoding necessary as [title] is safe. https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#:~:text=Safe%20HTML%20Attributes%20include
+		iframeEl.title = this.playLabel
+		iframeEl.allow =
+			'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'
+		iframeEl.allowFullscreen = true
+		// Required by Youtube to fix Error 153
+		iframeEl.referrerPolicy = 'strict-origin-when-cross-origin'
+		// AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
+		// https://stackoverflow.com/q/64959723/89484
+		iframeEl.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(this.videoId)}?${this.getParams().toString()}`
+		return iframeEl
+	}
+
+	/**
+	 * In the spirit of the `lowsrc` attribute and progressive JPEGs, we'll upgrade the reliable
+	 * poster image to a higher resolution one, if it's available.
+	 * Interestingly this sddefault webp is often smaller in filesize, but we will still attempt it second
+	 * because getting _an_ image in front of the user if our first priority.
+	 *
+	 * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md for more details
+	 */
+	upgradePosterImage() {
+		// Defer to reduce network contention.
+		setTimeout(() => {
+			const webpUrl = `https://i.ytimg.com/vi_webp/${this.videoId}/sddefault.webp`
+			const img = new Image()
+			img.fetchPriority = 'low' // low priority to reduce network contention
+			img.referrerpolicy = 'origin' // Not 100% sure it's needed, but https://github.com/ampproject/amphtml/pull/3940
+			img.src = webpUrl
+			img.onload = (e) => {
+				// A pretty ugly hack since onerror won't fire on YouTube image 404. This is (probably) due to
+				// Youtube's style of returning data even with a 404 status. That data is a 120x90 placeholder image.
+				// … per "annoying yt 404 behavior" in the .md
+				const noAvailablePoster =
+					e.target.naturalHeight == 90 && e.target.naturalWidth == 120
+				if (noAvailablePoster) return
+
+				this.style.backgroundImage = `url("${webpUrl}")`
+			}
+		}, 100)
+	}
+}
+// Register custom element
+customElements.define('lite-youtube', LiteYTEmbed)

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,4 +1,8 @@
 import { examplePath, examplePurpose } from '#src/example-thread.ts'
+import {
+	homepageDemoVideoTitle,
+	homepageDemoVideoWatchUrl,
+} from '#src/homepage-demo-video.ts'
 import { plans } from '#src/limits.ts'
 import { oauthPaths } from '#src/oauth-paths.ts'
 import { siteDescription } from '#src/site-pages.ts'
@@ -296,6 +300,8 @@ description: ${siteDescription}
 Skip the human relay. Open a thread so your agent can talk to someone else's — a bug, a PR, an integration — while you watch the read-only chat.
 
 [Watch an example thread](${origin}${examplePath}) — Harbor Ledger and Relay Webhooks agents pair on \`invoice.paid\`.
+
+[Watch the demo](${homepageDemoVideoWatchUrl}) — ${homepageDemoVideoTitle}.
 
 ## Stop being the messenger
 

--- a/src/homepage-demo-video.node.test.ts
+++ b/src/homepage-demo-video.node.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import { handleRequest } from '#src/index.ts'
+import {
+	homepageDemoVideoId,
+	homepageDemoVideoTitle,
+	homepageDemoVideoWatchUrl,
+	liteYoutubeEmbedCssPath,
+	liteYoutubeEmbedJsPath,
+} from '#src/homepage-demo-video.ts'
+import { createTestEnv, request } from '#src/test-support.ts'
+
+const publicDir = join(dirname(fileURLToPath(import.meta.url)), '../public')
+
+test('homepage embeds the demo with lite-youtube-embed', async () => {
+	const home = await handleRequest(request('/'), createTestEnv())
+	expect(home.status).toBe(200)
+	const html = await home.text()
+	expect(html).toContain('A replay of the')
+	expect(html).toContain(`<lite-youtube videoid="${homepageDemoVideoId}"`)
+	expect(html).toContain(homepageDemoVideoTitle)
+	expect(html).toContain(`href="${homepageDemoVideoWatchUrl}"`)
+	expect(html).toContain(`href="${liteYoutubeEmbedCssPath}"`)
+	expect(html).toContain(`src="${liteYoutubeEmbedJsPath}"`)
+	expect(html).toContain('class="lyt-playbtn"')
+	expect(html.indexOf('A replay of the')).toBeLessThan(
+		html.indexOf(`<lite-youtube videoid="${homepageDemoVideoId}"`),
+	)
+})
+
+test('homepage markdown links the demo video', async () => {
+	const markdown = await handleRequest(
+		request('/', { headers: { accept: 'text/markdown' } }),
+		createTestEnv(),
+	)
+	expect(markdown.status).toBe(200)
+	const body = await markdown.text()
+	expect(body).toContain(`[Watch the demo](${homepageDemoVideoWatchUrl})`)
+	expect(body).toContain(homepageDemoVideoTitle)
+})
+
+test('vendored lite-youtube-embed files are the custom element', () => {
+	const css = readFileSync(join(publicDir, 'lite-yt-embed.css'), 'utf8')
+	const js = readFileSync(join(publicDir, 'lite-yt-embed.js'), 'utf8')
+	expect(css).toContain('Apache License 2.0')
+	expect(css).toContain('lite-youtube')
+	expect(css).toContain('.lyt-playbtn')
+	expect(js).toContain('Apache License 2.0')
+	expect(js).toContain("customElements.define('lite-youtube', LiteYTEmbed)")
+})

--- a/src/homepage-demo-video.ts
+++ b/src/homepage-demo-video.ts
@@ -1,0 +1,11 @@
+export const homepageDemoVideoId = 'wcVhZiDw5V4'
+export const homepageDemoVideoTitle = 'Let your agents talk: Kody.exchange demo'
+export const homepageDemoVideoWatchUrl = `https://youtu.be/${homepageDemoVideoId}`
+export const homepageDemoVideoPosterUrl = `https://i.ytimg.com/vi/${homepageDemoVideoId}/hqdefault.jpg`
+export const liteYoutubeEmbedCssPath = '/lite-yt-embed.css'
+export const liteYoutubeEmbedJsPath = '/lite-yt-embed.js'
+
+export function homepageDemoVideoHead() {
+	return `<link rel="stylesheet" href="${liteYoutubeEmbedCssPath}" />
+	<script src="${liteYoutubeEmbedJsPath}" defer></script>`
+}

--- a/src/html.ts
+++ b/src/html.ts
@@ -9,6 +9,12 @@ import {
 	examplePath,
 	exampleRelayAgentId,
 } from '#src/example-thread.ts'
+import {
+	homepageDemoVideoId,
+	homepageDemoVideoPosterUrl,
+	homepageDemoVideoTitle,
+	homepageDemoVideoWatchUrl,
+} from '#src/homepage-demo-video.ts'
 import { plans } from '#src/limits.ts'
 import { siteDescription } from '#src/site-pages.ts'
 import { userHasPermission, type SessionUser } from '#src/permissions.ts'
@@ -263,6 +269,8 @@ main.thread-page { width: min(720px, calc(100% - 2rem)); }
 .typing-dot:nth-child(2) { animation-delay: .2s; }
 .typing-dot:nth-child(3) { animation-delay: .4s; }
 @keyframes typing-blink { 0%, 80%, 100% { opacity: .25; } 40% { opacity: 1; } }
+.demo-video { margin: 1rem 0 0; }
+.demo-video lite-youtube { max-width: none; width: 100%; border-radius: 12px; overflow: hidden; border: 1px solid var(--line); }
 @media (prefers-reduced-motion: reduce) {
 	.demo-chat { height: auto; }
 	.bubble[data-demo-shown] { animation: none; }
@@ -650,6 +658,18 @@ function demoMessage(message: MessageEnvelope): MessageEnvelope {
 	}
 }
 
+function homepageDemoVideoHtml() {
+	const playLabel = `Play Video: ${homepageDemoVideoTitle}`
+	return `
+		<figure class="demo-video">
+			<lite-youtube videoid="${escapeHtml(homepageDemoVideoId)}" playlabel="${escapeHtml(playLabel)}" title="${escapeHtml(homepageDemoVideoTitle)}" style="background-image: url('${escapeHtml(homepageDemoVideoPosterUrl)}');">
+				<a href="${escapeHtml(homepageDemoVideoWatchUrl)}" class="lyt-playbtn">
+					<span class="lyt-visually-hidden">${escapeHtml(playLabel)}</span>
+				</a>
+			</lite-youtube>
+		</figure>`
+}
+
 export function homePage(
 	baseUrl: string,
 	user: SessionUser | UserRow | null = null,
@@ -675,6 +695,7 @@ export function homePage(
 			)
 			.join('')}</div>
 		<p class="tiny">A replay of the <a href="${examplePath}">example thread</a> — no human relaying in sight.</p>
+		${homepageDemoVideoHtml()}
 	</section>
 	<div class="jobs">
 		<article class="card">

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -21,6 +21,7 @@ import {
 	textResponse,
 } from '#src/discover.ts'
 import { type AppEnv, appBaseUrl } from '#src/env.ts'
+import { homepageDemoVideoHead } from '#src/homepage-demo-video.ts'
 import {
 	accountThreadActionsScript,
 	copyPromptScript,
@@ -123,8 +124,8 @@ export async function renderPage(
 				layout({
 					...common,
 					title: 'kody.exchange',
-					extraHead:
-						'<link rel="preload" as="image" href="/icon.png" fetchpriority="high" />',
+					extraHead: `${homepageDemoVideoHead()}
+						<link rel="preload" as="image" href="/icon.png" fetchpriority="high" />`,
 					body: homePage(baseUrl, user),
 				}),
 			)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Embed [Let your agents talk: Kody.exchange demo](https://youtu.be/wcVhZiDw5V4) on the homepage, directly under “A replay of the example thread — no human relaying in sight.”

Paul Irish’s [lite-youtube-embed](https://github.com/paulirish/lite-youtube-embed) is still the usual facade for this (poster + play button until click, `youtube-nocookie.com` after). There isn’t a clearer modern replacement for a single homepage embed, so this vendors v0.3.4 and uses the progressive-enhancement pattern: the play control is a real YouTube link if JS never runs.

## Why this shape

- No extra npm runtime dep — CSS/JS live in `public/` with the Apache-2.0 notice.
- Homepage markdown (`Accept: text/markdown`) gets the same watch link.
- Poster stays `hqdefault` (this video has no `maxresdefault`).

## Risk

**Low.** Marketing/homepage only. No auth, billing, or thread protocol changes.

## Test plan

- [x] Homepage HTML includes `<lite-youtube videoid="wcVhZiDw5V4">` after the replay caption
- [x] Markdown homepage links `https://youtu.be/wcVhZiDw5V4`
- [x] Vendored CSS/JS still define the custom element
- [x] `npm run validate` on this branch (26 files / 130 tests)
- [ ] After merge: production Deploy, then `GET https://kody.exchange/health` matches the merge SHA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b63cfec7-43c7-43c2-97f3-ae0fb20bcf4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b63cfec7-43c7-43c2-97f3-ae0fb20bcf4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a demo video to the homepage with a responsive, accessible play experience.
  * Added lazy-loading YouTube playback with poster imagery and a fallback watch link.
  * Added connection warming and deferred video loading for improved performance.
* **Bug Fixes**
  * Added keyboard-friendly video controls and screen-reader support.
* **Tests**
  * Added coverage for video rendering, metadata, assets, accessibility markup, and fallback links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->