### PR TITLE
Reject opaque and malformed MCP Origins

### DIFF
--- a/src/mcp.node.test.ts
+++ b/src/mcp.node.test.ts
@@ -197,6 +197,68 @@ test('modern server/discover answers 2026-07-28', async () => {
 	)
 })
 
+test('MCP rejects opaque and malformed Origins', async () => {
+	const env = createTestEnv()
+	const owner = await createSignedInUser(env)
+	env.OAUTH_USER = owner.user
+	const initialize = {
+		jsonrpc: '2.0',
+		id: 1,
+		method: 'initialize',
+		params: {
+			protocolVersion: '2025-03-26',
+			capabilities: {},
+			clientInfo: { name: 'test', version: '1' },
+		},
+	}
+
+	const opaque = await mcpRpc(env, initialize, { origin: 'null' })
+	expect(opaque.status).toBe(403)
+	expect((opaque.body as unknown as { code: string }).code).toBe('bad_origin')
+
+	const malformed = await handleRequest(
+		request('/mcp', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				origin: 'not a url',
+			},
+			body: JSON.stringify(initialize),
+		}),
+		env,
+	)
+	expect(malformed.status).toBe(403)
+	expect(((await malformed.json()) as { code: string }).code).toBe('bad_origin')
+
+	const fileOrigin = await mcpRpc(env, initialize, { origin: 'file://' })
+	expect(fileOrigin.status).toBe(403)
+
+	const allowed = await mcpRpc(env, initialize, {
+		origin: 'https://claude.ai',
+	})
+	expect(allowed.status).toBe(200)
+	expect(allowed.body.result?.protocolVersion).toBe('2025-03-26')
+})
+
+test('worker rejects opaque Origin before OAuth', async () => {
+	const env = createTestEnv()
+	const response = await worker.fetch(
+		request('/mcp', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				origin: 'null',
+			},
+			body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+		}),
+		env,
+		executionContext(),
+	)
+	expect(response.status).toBe(403)
+	const body = (await response.json()) as { code: string }
+	expect(body.code).toBe('bad_origin')
+})
+
 test('worker OAuthProvider challenges unauthenticated MCP POSTs', async () => {
 	const env = createTestEnv()
 	const response = await worker.fetch(

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -142,6 +142,32 @@ export function isMcpBrowserNavigation(request: Request) {
 	)
 }
 
+// Browser MCP clients come from many hosts. Allow any well-formed http(s)
+// Origin, and reject opaque / malformed / non-HTTP values before the Agents
+// handler (which uses `allowedOriginHostnames: '*'` only after this gate).
+export function mcpOriginRejection(request: Request) {
+	const origin = request.headers.get('origin')
+	if (origin === null || origin === '') return null
+	if (origin === 'null') {
+		return json(
+			{ ok: false, error: 'Invalid Origin.', code: 'bad_origin' },
+			403,
+		)
+	}
+	try {
+		const parsed = new URL(origin)
+		if (
+			(parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+			parsed.hostname
+		) {
+			return null
+		}
+	} catch {
+		// malformed Origin
+	}
+	return json({ ok: false, error: 'Invalid Origin.', code: 'bad_origin' }, 403)
+}
+
 function prefersJsonRpcBody(request: Request) {
 	const accept = request.headers.get('accept') ?? ''
 	return !accept.includes('text/event-stream')
@@ -368,14 +394,17 @@ export async function handleMcp(
 		return json({ ok: false, error: 'Method not allowed.' }, 405)
 	}
 
+	const originRejection = mcpOriginRejection(request)
+	if (originRejection) return originRejection
+
 	const handler = createMcpHandler(
 		() => createExchangeMcpServer({ request, env, user, ctx }),
 		{
 			route: oauthPaths.mcp,
 			legacy: 'stateless',
 			responseMode: 'json',
-			// OAuthProvider already authenticated this request. Browser MCP
-			// clients send arbitrary Origins; Host is enforced by the zone route.
+			// Trusted middleware above already rejected opaque/malformed Origins.
+			// Remaining well-formed http(s) Origins come from arbitrary MCP clients.
 			allowedOriginHostnames: '*',
 		},
 	)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3,7 +3,11 @@ import * as Sentry from '@sentry/cloudflare'
 import { handleRequest } from '#src/index.ts'
 import { type AppEnv } from '#src/env.ts'
 import { applySecurityHeaders, httpsRedirect } from '#src/https.ts'
-import { handleMcp, isMcpBrowserNavigation } from '#src/mcp.ts'
+import {
+	handleMcp,
+	isMcpBrowserNavigation,
+	mcpOriginRejection,
+} from '#src/mcp.ts'
 import {
 	getDurableObjectSentryOptions,
 	getSentryOptions,
@@ -103,6 +107,12 @@ const workerHandler = {
 			return handleRequest(request, env, ctx).then((response) =>
 				applySecurityHeaders(request, response),
 			)
+		}
+		if (pathname === oauthPaths.mcp) {
+			const originRejection = mcpOriginRejection(request)
+			if (originRejection) {
+				return applySecurityHeaders(request, originRejection)
+			}
 		}
 		return oauthProvider
 			.fetch(request, env, ctx)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #48. CodeRabbit flagged `allowedOriginHostnames: '*'` because it turns off Agents SDK Origin validation, including malformed and opaque Origins.

## Change

- Add `mcpOriginRejection()` before `createMcpHandler` and in the Worker `/mcp` path (before OAuth).
- Reject `null`, non-http(s), and unparseable Origins with `403 bad_origin`.
- Allow well-formed `http(s)` Origins from arbitrary MCP clients (Cursor, Claude, inspectors).
- Keep `allowedOriginHostnames: '*'` only after that gate, which is the documented pattern when trusted middleware already validated Origins.

## Risk

**Low.** Auth is unchanged. Origin-less non-browser clients still work.

## Test plan

- `npm run validate` (136 tests)
- New coverage: opaque `Origin: null` via `handleRequest` and `worker.fetch`, malformed and `file://` Origins, and `https://claude.ai` still initializes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e00bf77a-5d64-4c21-b014-11d012e200ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e00bf77a-5d64-4c21-b014-11d012e200ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

