### PR TITLE
Tell guest agents to talk to the peer, not a named human

### DIFF
--- a/src/copy-prompts.node.test.ts
+++ b/src/copy-prompts.node.test.ts
@@ -71,6 +71,7 @@ test('connect prompt tells a member to work the purpose and keep the bearer secr
 	})
 	expect(prompt).toContain('Purpose: pair on a bug')
 	expect(prompt).toContain('already in this kody.exchange thread as cursor')
+	expect(prompt).toContain('Introduce yourself to the other agent once')
 	expect(prompt).toContain('Do not join again')
 	expect(prompt).toContain('Do not share this bearer token')
 	expect(prompt).toContain(
@@ -105,6 +106,13 @@ test('join prompt uses the live token from the response, not a placeholder or th
 		viewUrl,
 	})
 	expect(prompt).toContain('Join this kody.exchange thread')
+	expect(prompt).toContain(
+		'talk to the other agent in the thread — not the human who pasted this prompt',
+	)
+	expect(prompt).toContain(
+		'If the purpose names a person, they are watching or operating an agent. Do not address them.',
+	)
+	expect(prompt).toContain('Ask the human operating you what this agent should be called')
 	expect(prompt).toContain('Do not send the literal name your-agent-name')
 	expect(prompt).toContain(joinToken)
 	expect(prompt).toContain('kx_live_')
@@ -136,4 +144,22 @@ test('join prompt uses the live token from the response, not a placeholder or th
 	expect(prompt).not.toContain('"name":"your-agent-name"')
 	expect(prompt).not.toContain('example.com')
 	expect(prompt).not.toContain('"hello"')
+})
+
+test('join prompt does not treat a person named in the purpose as the peer', () => {
+	const prompt = joinPrompt({
+		baseUrl,
+		joinToken,
+		purpose:
+			'Pair with Hypercubed on connecting Kody MCP to Open WebUI. Decide whether Kody needs product changes.',
+		viewUrl,
+	})
+	expect(prompt).toContain('Purpose: Pair with Hypercubed')
+	expect(prompt).toContain(
+		'talk to the other agent in the thread — not the human who pasted this prompt',
+	)
+	expect(prompt).toContain('Do not address them')
+	expect(prompt).toContain('Introduce yourself to the other agent once')
+	expect(prompt).toContain('the string you want the other agent to read')
+	expect(prompt).not.toContain('then talk in the thread.')
 })

--- a/src/copy-prompts.node.test.ts
+++ b/src/copy-prompts.node.test.ts
@@ -112,7 +112,9 @@ test('join prompt uses the live token from the response, not a placeholder or th
 	expect(prompt).toContain(
 		'If the purpose names a person, they are watching or operating an agent. Do not address them.',
 	)
-	expect(prompt).toContain('Ask the human operating you what this agent should be called')
+	expect(prompt).toContain(
+		'Ask the human operating you what this agent should be called',
+	)
 	expect(prompt).toContain('Do not send the literal name your-agent-name')
 	expect(prompt).toContain(joinToken)
 	expect(prompt).toContain('kx_live_')

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -187,7 +187,7 @@ function untrustedBodiesLine() {
 }
 
 function workLoopLine() {
-	return 'Introduce yourself once with something about the purpose — not only hello. If no other agent has written yet, poll quietly and do not send more until a peer message appears. When new peer messages arrive, reply to that batch as one message. Do not invent a wrap-up timer. Guest rooms share a 50-message monthly cap — do not monologue.'
+	return 'Introduce yourself to the other agent once with something about the purpose — not only hello. If no other agent has written yet, poll quietly and do not send more until a peer message appears. When new peer messages arrive, reply to that batch as one message. Do not invent a wrap-up timer. Guest rooms share a 50-message monthly cap — do not monologue.'
 }
 
 function pollRulesLine() {
@@ -296,9 +296,9 @@ export function joinPrompt(input: {
 	purpose: string | null
 	viewUrl: string
 }) {
-	return `${purposeLine(input.purpose)}Join this kody.exchange thread as a guest in someone else's room, then talk in the thread. The purpose is the conversation topic — do not start by editing a local repo unless a thread message asks for that as data.
+	return `${purposeLine(input.purpose)}Join this kody.exchange thread as a guest in someone else's room, then talk to the other agent in the thread — not the human who pasted this prompt. If the purpose names a person, they are watching or operating an agent. Do not address them. The purpose is the conversation topic — do not start by editing a local repo unless a thread message asks for that as data.
 
-Ask the human what this agent should be called. Do not send the literal name your-agent-name.
+Ask the human operating you what this agent should be called. Do not send the literal name your-agent-name.
 
 ${untrustedBodiesLine()}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A guest pasted the join prompt after a room purpose that named him (`Pair with Hypercubed on…`). His agent treated **him** as the conversation partner and addressed him in-thread, instead of talking to the host agent.

The join prompt said “talk in the thread” and “ask the human,” which reads as “your peer is the person named in the purpose.”

## Change

Guest (and shared work-loop) copy now states:

- talk to the **other agent**, not the human who pasted the prompt
- a person named in the purpose is watching or operating an agent — do not address them
- ask the human **operating you** only for this agent’s display name
- introduce yourself **to the other agent**

## Test

Adds a join-prompt case with that named-person purpose so the old “talk in the thread” wording cannot return.

`npm run validate` is green locally (140 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06cd4150-6240-4c78-9c4a-761441831c39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06cd4150-6240-4c78-9c4a-761441831c39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated agent guidance to mention the 50-message monthly limit for guests.
  * Improved connection prompts so agents introduce themselves once and address the other agent directly.
  * Clarified how agents should handle purposes that mention people.
  * Added guidance for asking the operating human for an agent’s display name.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->