### PR TITLE
Move Admin to the footer and drop Features from nav

### DIFF
--- a/src/admin.node.test.ts
+++ b/src/admin.node.test.ts
@@ -207,7 +207,9 @@ test('admin nav follows read:user:any, not the GitHub login', async () => {
 			env,
 		)
 	).text()
-	expect(operatorHtml).toContain('href="/admin"')
+	expect(operatorHtml).toMatch(/<footer>[\s\S]*href="\/admin"/)
+	expect(operatorHtml).not.toMatch(/<nav>[\s\S]*href="\/admin"[\s\S]*<\/nav>/)
+	expect(operatorHtml).not.toContain('>Features</a>')
 
 	const strangerHtml = await (
 		await handleRequest(

--- a/src/home-page.node.test.ts
+++ b/src/home-page.node.test.ts
@@ -9,7 +9,7 @@ import {
 test('homepage puts the prompt and short chat above the video and pricing', async () => {
 	const html = await (await handleRequest(request('/'), createTestEnv())).text()
 	expect(html).toContain('class="home-page"')
-	expect(html).toContain('href="#features"')
+	expect(html).not.toContain('>Features</a>')
 	expect(html).toContain('href="#pricing"')
 	expect(html).toContain('id="home-prompt"')
 	expect(html).toContain('id="cta-prompt"')

--- a/src/html.ts
+++ b/src/html.ts
@@ -116,7 +116,6 @@ export function layout(input: {
 	<header class="top">
 		<a class="mark" href="/"><img src="/icon.png" alt="" width="40" height="40" decoding="async" /><span>kody.exchange</span></a>
 		<nav>
-			<a href="${input.path === '/' ? '#features' : '/#features'}">Features</a>
 			<a href="${input.path === '/' ? '#pricing' : '/pricing'}" ${ariaCurrent(input.path, '/pricing')}>Pricing</a>
 			${
 				input.path === '/'
@@ -126,12 +125,7 @@ export function layout(input: {
 			<a href="${safetyPath}" ${ariaCurrent(input.path, safetyPath)}>${safetyNavLabel}</a>
 			${
 				signedIn
-					? `${
-							userHasPermission(input.user, 'read:user:any')
-								? `<a href="/admin" ${ariaCurrent(input.path, '/admin')}>Admin</a>
-						`
-								: ''
-						}<a href="/account" ${ariaCurrent(input.path, '/account')}>Threads</a>
+					? `<a href="/account" ${ariaCurrent(input.path, '/account')}>Threads</a>
 						<form method="post" action="/auth/logout"><button type="submit">Sign out</button></form>`
 					: githubOAuthConfigured(input.env)
 						? `<a class="btn ghost" href="/auth/github">Sign in with GitHub</a>`
@@ -144,6 +138,11 @@ export function layout(input: {
 		<p>Part of the Kody family: <a href="https://kody.codes">kody.codes</a> · <a href="https://kody.video">kody.video</a> · kody.exchange</p>
 		<p class="tiny">Support: <a href="mailto:support@kody.exchange">support@kody.exchange</a></p>
 		<p class="tiny"><a href="/docs">Docs</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> · <a href="${safetyPath}">${safetyNavLabel}</a> · <a href="https://github.com/kentcdodds/kody-exchange">Source</a> · Made by Kent C. Dodds</p>
+		${
+			userHasPermission(input.user, 'read:user:any')
+				? `<p class="tiny"><a href="/admin" ${ariaCurrent(input.path, '/admin')}>Admin</a></p>`
+				: ''
+		}
 	</footer>
 </body>
 </html>`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Signed-in admins see six header links. On a phone that wraps badly (`Features`, `Pricing`, `Is this safe?`, `Admin`, `Threads`, `Sign out`).

## Change

- Remove **Features** from the top nav. The homepage still has the `#features` section.
- Move **Admin** to the last footer line, still gated on `read:user:any`, still `aria-current` on `/admin`.

Header for a signed-in admin on home is now Pricing, Is this safe?, Threads, Sign out.

`npm run validate` is green locally (140 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06cd4150-6240-4c78-9c4a-761441831c39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06cd4150-6240-4c78-9c4a-761441831c39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the Features link from the top navigation and account page.
  - Kept Threads available to signed-in users.
  - Moved the Admin link to the footer, where it appears only for users with the required permission.
- **Tests**
  - Updated navigation tests to verify the revised link visibility and placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->