### PR TITLE
Show Docs in the site nav on every page

### DIFF
--- a/src/home-page.node.test.ts
+++ b/src/home-page.node.test.ts
@@ -70,10 +70,10 @@ test('signed-out public pages share Pricing, Docs, and safety in the nav', async
 	for (const page of publicPages) {
 		const html = await (await handleRequest(request(page.path), env)).text()
 		const nav = navHtml(html)
-		expect(nav, page.path).toContain('>Pricing</a>')
-		expect(nav, page.path).toContain('href="/docs"')
-		expect(nav, page.path).toContain('>Docs</a>')
-		expect(nav, page.path).toContain(`>${safetyNavLabel}<`)
-		expect(nav, page.path).not.toContain('>Features</a>')
+		expect(nav).toContain('>Pricing</a>')
+		expect(nav).toContain('href="/docs"')
+		expect(nav).toContain('>Docs</a>')
+		expect(nav).toContain(`>${safetyNavLabel}<`)
+		expect(nav).not.toContain('>Features</a>')
 	}
 })

--- a/src/home-page.node.test.ts
+++ b/src/home-page.node.test.ts
@@ -1,10 +1,16 @@
 import { expect, test } from 'vitest'
+import { safetyNavLabel } from '#src/html.ts'
 import { handleRequest } from '#src/index.ts'
+import { publicPages } from '#src/site-pages.ts'
 import {
 	createSignedInUser,
 	createTestEnv,
 	request,
 } from '#src/test-support.ts'
+
+function navHtml(html: string) {
+	return html.match(/<nav>([\s\S]*?)<\/nav>/)?.[1] ?? ''
+}
 
 test('homepage puts the prompt and short chat above the video and pricing', async () => {
 	const html = await (await handleRequest(request('/'), createTestEnv())).text()
@@ -29,7 +35,8 @@ test('homepage puts the prompt and short chat above the video and pricing', asyn
 		html.indexOf('id="pricing"'),
 	)
 	expect(html.indexOf('id="pricing"')).toBeLessThan(html.indexOf('id="cta"'))
-	expect(html).toContain('>Docs</a>')
+	expect(navHtml(html)).toContain('href="/docs"')
+	expect(navHtml(html)).toContain('>Docs</a>')
 	expect(html).toContain(
 		'.home-hero { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 2.2rem; align-items: stretch; }',
 	)
@@ -56,4 +63,17 @@ test('signed-in homepage keeps the account prompt in both boxes', async () => {
 	expect(html).toContain('Your threads')
 	expect(html).toContain('href="/account"')
 	expect(html).not.toContain('Start a guest thread')
+})
+
+test('signed-out public pages share Pricing, Docs, and safety in the nav', async () => {
+	const env = createTestEnv()
+	for (const page of publicPages) {
+		const html = await (await handleRequest(request(page.path), env)).text()
+		const nav = navHtml(html)
+		expect(nav, page.path).toContain('>Pricing</a>')
+		expect(nav, page.path).toContain('href="/docs"')
+		expect(nav, page.path).toContain('>Docs</a>')
+		expect(nav, page.path).toContain(`>${safetyNavLabel}<`)
+		expect(nav, page.path).not.toContain('>Features</a>')
+	}
 })

--- a/src/html.ts
+++ b/src/html.ts
@@ -117,11 +117,7 @@ export function layout(input: {
 		<a class="mark" href="/"><img src="/icon.png" alt="" width="40" height="40" decoding="async" /><span>kody.exchange</span></a>
 		<nav>
 			<a href="${input.path === '/' ? '#pricing' : '/pricing'}" ${ariaCurrent(input.path, '/pricing')}>Pricing</a>
-			${
-				input.path === '/'
-					? ''
-					: `<a href="/docs" ${ariaCurrent(input.path, '/docs')}>Docs</a>`
-			}
+			<a href="/docs" ${ariaCurrent(input.path, '/docs')}>Docs</a>
 			<a href="${safetyPath}" ${ariaCurrent(input.path, safetyPath)}>${safetyNavLabel}</a>
 			${
 				signedIn


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The homepage header omitted Docs while `/safety` and the other public pages showed it. The header now always includes Pricing, Docs, and Is this safe?, and the homepage test asserts Docs is in `<nav>` (not only the footer).

Pricing on `/` still jumps to `#pricing`. Everywhere else it still goes to `/pricing`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8209fe57-3653-4caa-96f2-1c9476ade90d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8209fe57-3653-4caa-96f2-1c9476ade90d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docs navigation is now consistently available, including from the homepage.
  * Improved navigation consistency across publicly accessible pages.
* **Tests**
  * Added coverage verifying shared navigation links and safety-link behavior across signed-out pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->