### PR TITLE
Filter D1 storage operation timeout Sentry noise

### DIFF
--- a/src/sentry-options.node.test.ts
+++ b/src/sentry-options.node.test.ts
@@ -2,6 +2,7 @@ import { type ErrorEvent } from '@sentry/cloudflare'
 import { expect, test } from 'vitest'
 import {
 	buildSentryOptions,
+	d1StorageOperationTimeoutResetMessage,
 	durableObjectCodeUpdatedResetMessage,
 	durableObjectIsolateMemoryResetMessage,
 	filterSentryEvent,
@@ -99,6 +100,19 @@ test('drops retryable D1 platform noise and keeps real errors', () => {
 		),
 	).toBeNull()
 	expect(filterSentryEvent(errorEvent('Network connection lost'))).toBeNull()
+	expect(
+		filterSentryEvent(errorEvent(d1StorageOperationTimeoutResetMessage)),
+	).toBeNull()
+	expect(
+		filterSentryEvent(
+			errorEvent(`D1_ERROR: ${d1StorageOperationTimeoutResetMessage}`),
+		),
+	).toBeNull()
+	expect(
+		filterSentryEvent(
+			errorEvent(`Error: D1_ERROR: ${d1StorageOperationTimeoutResetMessage}`),
+		),
+	).toBeNull()
 	const kept = errorEvent('thread create failed')
 	expect(filterSentryEvent(kept)).toBe(kept)
 })

--- a/src/sentry-options.node.test.ts
+++ b/src/sentry-options.node.test.ts
@@ -105,6 +105,11 @@ test('drops retryable D1 platform noise and keeps real errors', () => {
 	).toBeNull()
 	expect(
 		filterSentryEvent(
+			errorEvent(d1StorageOperationTimeoutResetMessage.replace(/\.$/, '')),
+		),
+	).toBeNull()
+	expect(
+		filterSentryEvent(
 			errorEvent(`D1_ERROR: ${d1StorageOperationTimeoutResetMessage}`),
 		),
 	).toBeNull()

--- a/src/sentry-options.ts
+++ b/src/sentry-options.ts
@@ -32,8 +32,12 @@ export function isRetryableD1PlatformMessage(message: string) {
 		return true
 	}
 	if (normalized === 'Network connection lost') return true
-	// Cloudflare may wrap this as `D1_ERROR: …`.
-	if (normalized.includes(d1StorageOperationTimeoutResetMessage)) return true
+	// Cloudflare may wrap this as `D1_ERROR: …`, with or without a trailing `.`.
+	const d1StorageTimeoutStem = d1StorageOperationTimeoutResetMessage.replace(
+		/\.$/,
+		'',
+	)
+	if (normalized.includes(d1StorageTimeoutStem)) return true
 	return /^internal error in D1 DB storage caused object to be reset;\s*reference\s*=\s*[A-Za-z0-9]+$/i.test(
 		normalized,
 	)

--- a/src/sentry-options.ts
+++ b/src/sentry-options.ts
@@ -16,6 +16,10 @@ function withoutErrorPrefix(message: string) {
  * Transient D1 / SQLite platform unavailability. Call sites retry; these
  * should not open or regress Sentry issues.
  */
+/** D1 analogue of durableObjectStorageOperationTimeoutResetMessage. */
+export const d1StorageOperationTimeoutResetMessage =
+	'D1 DB storage operation exceeded timeout which caused object to be reset.'
+
 export function isRetryableD1PlatformMessage(message: string) {
 	const normalized = withoutErrorPrefix(message)
 	if (normalized.includes('SQLITE_BUSY')) return true
@@ -28,6 +32,8 @@ export function isRetryableD1PlatformMessage(message: string) {
 		return true
 	}
 	if (normalized === 'Network connection lost') return true
+	// Cloudflare may wrap this as `D1_ERROR: …`.
+	if (normalized.includes(d1StorageOperationTimeoutResetMessage)) return true
 	return /^internal error in D1 DB storage caused object to be reset;\s*reference\s*=\s*[A-Za-z0-9]+$/i.test(
 		normalized,
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Transient Cloudflare D1 platform error `D1 DB storage operation exceeded timeout which caused object to be reset` (often wrapped as `D1_ERROR: …`) was opening Sentry issues. This is the D1 analogue of the already-filtered Durable Object storage-operation timeout reset.

Seer’s OAuth-ordering hypothesis does not hold: event breadcrumbs show GitHub token/user/emails completing in ~300ms, then D1 hanging ~30s. Sibling KODY-EXCHANGE-1 hit the same signature on a thread messages URL in the same second — a shared platform blip, not an OAuth-path bug.

## Changes

- Extend `isRetryableD1PlatformMessage` to drop this signature (bare, `D1_ERROR:`, and `Error: D1_ERROR:` forms).
- Cover the filter in `src/sentry-options.node.test.ts`.

## Risk

Low — narrow `beforeSend` filter matching an established platform-noise pattern; no auth/DB behavior change.

## Test plan

- [x] `npm run validate`
- [ ] CI green on this PR
- After merge: ignore Sentry issues KODY-EXCHANGE-2 and KODY-EXCHANGE-1 (same root cause).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa634eb5-970f-4c39-b488-f5eba077ad47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa634eb5-970f-4c39-b488-f5eba077ad47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

