### PR TITLE
Disable Sentry for local wrangler so localhost errors stop emailing

### DIFF
--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -34,7 +34,7 @@ Repo variables: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID` (`kody.exchange` z
 
 Wrangler vars (in `wrangler.jsonc` or `--var`): `APP_BASE_URL`, `APP_COMMIT_SHA`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `STRIPE_PRO_PRICE_ID`, `STRIPE_PAYMENT_LINK_URL`.
 
-Sentry project is `kody-exchange` in org `kent-c-dodds-tech-llc`. The DSN is a publishable client key (also overridable by the optional `SENTRY_DSN` Actions secret). The Worker skips the SDK when `SENTRY_DSN` is unset, `APP_COMMIT_SHA` is `dev` (local wrangler), or `SENTRY_ENVIRONMENT` is `development`. `SENTRY_TRACES_SAMPLE_RATE` is an optional JSON-number var (`0`–`1`; default `1.0`).
+Sentry project is `kody-exchange` in org `kent-c-dodds-tech-llc`. The DSN is a publishable client key (also overridable by the optional `SENTRY_DSN` Actions secret). The Worker disables the SDK when `SENTRY_DSN` is unset, `APP_COMMIT_SHA` is `dev` or empty (local wrangler), or `SENTRY_ENVIRONMENT` is `development`. Returning no options is not a skip — the SDK would then use the baked DSN and tag local wrangler as production. `beforeSend` also drops localhost request URLs. `SENTRY_TRACES_SAMPLE_RATE` is an optional JSON-number var (`0`–`1`; default `1.0`).
 
 Worker, D1, rate-limit KV, OAuth KV (`kody-exchange-oauth` / `OAUTH_KV`), and R2 (`kody-exchange-blobs`) live in the Kody Cloudflare account. Public hostname is `kody.exchange` only.
 

--- a/src/sentry-options.node.test.ts
+++ b/src/sentry-options.node.test.ts
@@ -23,22 +23,44 @@ function errorEvent(message: string, extra?: string): ErrorEvent {
 	} as ErrorEvent
 }
 
-test('skips Sentry when SENTRY_DSN is unset', () => {
-	expect(getSentryOptions(createTestEnv())).toBeUndefined()
-	expect(getSentryOptions(createTestEnv({ SENTRY_DSN: '   ' }))).toBeUndefined()
-	expect(getDurableObjectSentryOptions(createTestEnv()).dsn).toBeUndefined()
+test('disables Sentry when SENTRY_DSN is unset', () => {
+	expect(getSentryOptions(createTestEnv())).toMatchObject({
+		enabled: false,
+		dsn: '',
+	})
+	expect(getSentryOptions(createTestEnv({ SENTRY_DSN: '   ' }))).toMatchObject({
+		enabled: false,
+		dsn: '',
+	})
+	expect(getDurableObjectSentryOptions(createTestEnv())).toMatchObject({
+		enabled: false,
+		dsn: '',
+	})
 })
 
-test('skips Sentry for local wrangler (dev commit or environment)', () => {
+test('disables Sentry for local wrangler (dev, empty commit, or environment)', () => {
 	const localWithProductionDsn = createTestEnv({
 		SENTRY_DSN: 'https://public@o1.ingest.sentry.io/1',
 		APP_COMMIT_SHA: 'dev',
 		SENTRY_ENVIRONMENT: 'production',
 	})
-	expect(getSentryOptions(localWithProductionDsn)).toBeUndefined()
+	expect(getSentryOptions(localWithProductionDsn)).toMatchObject({
+		enabled: false,
+		dsn: '',
+	})
+	expect(getDurableObjectSentryOptions(localWithProductionDsn)).toMatchObject({
+		enabled: false,
+		dsn: '',
+	})
 	expect(
-		getDurableObjectSentryOptions(localWithProductionDsn).dsn,
-	).toBeUndefined()
+		getSentryOptions(
+			createTestEnv({
+				SENTRY_DSN: 'https://public@o1.ingest.sentry.io/1',
+				APP_COMMIT_SHA: '',
+				SENTRY_ENVIRONMENT: 'production',
+			}),
+		),
+	).toMatchObject({ enabled: false, dsn: '' })
 	expect(
 		getSentryOptions(
 			createTestEnv({
@@ -47,7 +69,7 @@ test('skips Sentry for local wrangler (dev commit or environment)', () => {
 				SENTRY_ENVIRONMENT: 'development',
 			}),
 		),
-	).toBeUndefined()
+	).toMatchObject({ enabled: false, dsn: '' })
 })
 
 test('builds options from the DSN, environment, and commit sha', () => {
@@ -120,6 +142,26 @@ test('drops retryable D1 platform noise and keeps real errors', () => {
 	).toBeNull()
 	const kept = errorEvent('thread create failed')
 	expect(filterSentryEvent(kept)).toBe(kept)
+})
+
+test('drops localhost request URLs so wrangler cannot email production', () => {
+	const fromRequest = errorEvent(
+		'D1_ERROR: no such table: threads: SQLITE_ERROR',
+	)
+	fromRequest.request = { url: 'http://localhost/v1/threads' }
+	expect(filterSentryEvent(fromRequest)).toBeNull()
+
+	const fromTag = errorEvent('thread create failed')
+	fromTag.tags = { url: 'http://127.0.0.1:8787/v1/threads' }
+	expect(filterSentryEvent(fromTag)).toBeNull()
+
+	const ipv6 = errorEvent('thread create failed')
+	ipv6.request = { url: 'http://[::1]:8787/health' }
+	expect(filterSentryEvent(ipv6)).toBeNull()
+
+	const production = errorEvent('thread create failed')
+	production.request = { url: 'https://kody.exchange/v1/threads' }
+	expect(filterSentryEvent(production)).toBe(production)
 })
 
 test('drops bare Durable Object platform resets only', () => {

--- a/src/sentry-options.ts
+++ b/src/sentry-options.ts
@@ -1,5 +1,31 @@
 import { type CloudflareOptions, type ErrorEvent } from '@sentry/cloudflare'
 import { type AppEnv } from '#src/env.ts'
+import { isLocalHostname } from '#src/https.ts'
+
+/** @sentry/cloudflare fills `dsn` from `env.SENTRY_DSN` when options omit it. */
+const disabledSentryOptions: CloudflareOptions = {
+	enabled: false,
+	dsn: '',
+	beforeSend: () => null,
+}
+
+function sentryEventUrl(event: ErrorEvent) {
+	const requestUrl = event.request?.url
+	if (typeof requestUrl === 'string' && requestUrl.trim()) return requestUrl
+	const urlTag = event.tags?.url
+	if (typeof urlTag === 'string' && urlTag.trim()) return urlTag
+	return undefined
+}
+
+export function isLocalSentryEvent(event: ErrorEvent) {
+	const url = sentryEventUrl(event)
+	if (!url) return false
+	try {
+		return isLocalHostname(new URL(url).hostname)
+	} catch {
+		return false
+	}
+}
 
 function sentryEventMessages(event: ErrorEvent) {
 	return [
@@ -107,6 +133,7 @@ export function filterDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
 }
 
 export function filterSentryEvent(event: ErrorEvent) {
+	if (isLocalSentryEvent(event)) return null
 	if (filterRetryableD1PlatformSentryEvent(event) === null) return null
 	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
 	return event
@@ -131,21 +158,24 @@ export function buildSentryOptions(env: AppEnv): CloudflareOptions {
 	}
 }
 
+export function isLocalSentryRuntime(env: AppEnv) {
+	const sha = env.APP_COMMIT_SHA?.trim()
+	if (!sha || sha === 'dev') return true
+	return (env.SENTRY_ENVIRONMENT?.trim() || 'development') === 'development'
+}
+
 /**
- * Skip Sentry when no DSN is configured, or when this is local wrangler
- * (`APP_COMMIT_SHA` stays `dev` in wrangler.jsonc; production deploy
- * overwrites it with the git SHA). Shared by the Worker wrapper and
- * ThreadRoom so a baked production DSN cannot report from `wrangler dev`.
+ * Shared by the Worker wrapper and ThreadRoom. Returning `undefined` is not a
+ * skip: `@sentry/cloudflare` then reads the baked `SENTRY_DSN` and reports
+ * local wrangler as production (no release). Disable the SDK instead.
  */
-export function getSentryOptions(env: AppEnv): CloudflareOptions | undefined {
+export function getSentryOptions(env: AppEnv): CloudflareOptions {
 	const options = buildSentryOptions(env)
-	if (!options.dsn) return undefined
-	if (env.APP_COMMIT_SHA === 'dev') return undefined
-	if (options.environment === 'development') return undefined
+	if (!options.dsn || isLocalSentryRuntime(env)) return disabledSentryOptions
 	return options
 }
 
 /** `instrumentDurableObjectWithSentry` requires an options object. */
 export function getDurableObjectSentryOptions(env: AppEnv): CloudflareOptions {
-	return getSentryOptions(env) ?? {}
+	return getSentryOptions(env)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Local `wrangler dev` was still reporting to production Sentry.

`@sentry/cloudflare` fills `dsn` from `env.SENTRY_DSN` when the options callback returns `undefined`. We treated “skip” as `undefined`, so a baked production DSN plus `SENTRY_ENVIRONMENT=production` sent events with no release. That produced [issue 7685776740](https://kent-c-dodds-tech-llc.sentry.io/issues/7685776740/) (`POST http://localhost/v1/threads`, `no such table: threads`) and the email.

This disables the SDK (`enabled: false`, empty `dsn`) for local wrangler (`APP_COMMIT_SHA` `dev`/empty, or `SENTRY_ENVIRONMENT=development`) and drops localhost request URLs in `beforeSend`.

Risk: **low**. Production `kody.exchange` reporting is unchanged.

- [x] Local validate (`npm run validate`) — 143 tests
- [x] CI green ([Validate](https://github.com/kentcdodds/kody-exchange/actions/runs/32542383795))
- [x] Bugbot — no issues

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07fc6ca8-184f-41f2-80cc-fc98505471a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07fc6ca8-184f-41f2-80cc-fc98505471a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled error reporting during local development and when no reporting configuration is available.
  - Prevented locally generated events, including localhost and loopback URLs, from being sent.
  - Ensured consistent disabled-state behavior across application components.

- **Documentation**
  - Clarified local error-reporting behavior and configuration requirements in the setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->