### PR TITLE
Require send-shipped-pr for ship-pr Discord summaries

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -78,6 +78,7 @@ use raw `post-message` and do **not** compute or guess token cost — the export
 fetches the billed Cursor Cloud Agent usage and formats the cost line.
 
 **agentId (required):**
+
 - In a Cursor Cloud Agent VM, read it from the metadata socket:
   curl -fsS --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}" http://cursor-agent/v1/meta-data/agent/id
 - Otherwise pass the `bc-` id from the agent URL you were launched as

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -72,15 +72,29 @@ until `commit` matches the merge SHA.
 
 ## Done → Discord
 
-Always summarize (merged or not) with agent / PR / CI / deploy links:
+Always summarize (merged or not) by calling
+`kody:@kentcdodds/discord/send-shipped-pr` with structured fields. Do **not**
+use raw `post-message` and do **not** compute or guess token cost — the export
+fetches the billed Cursor Cloud Agent usage and formats the cost line.
+
+**agentId (required):**
+- In a Cursor Cloud Agent VM, read it from the metadata socket:
+  curl -fsS --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}" http://cursor-agent/v1/meta-data/agent/id
+- Otherwise pass the `bc-` id from the agent URL you were launched as
+  (https://cursor.com/agents/{id}).
 
 ```javascript
-import postMessage from 'kody:@kentcdodds/discord/post-message'
+import sendShippedPr from 'kody:@kentcdodds/discord/send-shipped-pr'
 
 export default async function main() {
-	return postMessage({
-		channelId: '1491568683737157683',
-		content: '…summary with links…',
+	return sendShippedPr({
+		agentId, // bc- id from the metadata socket or launch URL
+		title: 'PR title',
+		summary: 'What shipped / parked / blocked and why.',
+		prUrl: 'https://github.com/owner/repo/pull/1',
+		repo: 'owner/repo',
+		extras: ['CI green', 'preview verified'],
+		status: 'Shipped', // or 'Parked' | 'Blocked'
 	})
 }
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Update only the **Done → Discord** section of `.agents/skills/ship-pr/SKILL.md`.

Agents must summarize by calling `kody:@kentcdodds/discord/send-shipped-pr` with structured fields (`agentId`, `title`, `summary`, `prUrl`, `repo`, `extras`, `status`) instead of raw `post-message` / freeform content.

They must not compute or guess token cost — the export fetches billed Cursor Cloud Agent usage.

`agentId` comes from the Cursor Cloud Agent metadata socket, or the `bc-` id from the agent launch URL.

## Unchanged

Risk, reviewers, loop, gates, and merge/deploy are unchanged. Official Kody Discord / kody-discord and ship-pr-devin are not touched.

## Test plan

- [x] Diff is confined to the Done → Discord section
- [x] Code sample uses tabs
- [x] Required fields and `Shipped` | `Parked` | `Blocked` status are documented
- [x] `oxfmt --check` (printWidth 80) is clean on `.agents/skills/ship-pr/SKILL.md` — blank line after the agentId heading

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b94ec5c9-d9fa-4102-8f10-baff45f505fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b94ec5c9-d9fa-4102-8f10-baff45f505fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

