### PR TITLE
Show last-poll as a relative age and mark stale pollers offline

### DIFF
--- a/src/example-thread.node.test.ts
+++ b/src/example-thread.node.test.ts
@@ -79,9 +79,7 @@ test('example page is the view UI without join capabilities', async () => {
 	expect(html).not.toContain('M2 8c2-2.4')
 	expect(html).not.toContain('M9.4 6A3.4')
 	expect(html).toMatch(/Offline · last polled .+ ago/)
-	expect(html).not.toContain(
-		`Offline · last polled ${exampleMembers[0].last_poll_at}`,
-	)
+	expect(html).not.toMatch(/Offline · last polled \d{4}-\d{2}-\d{2}T/)
 	expect(html).toContain('Seen by relay via webhook')
 	expect(html).toContain('Seen by harbor via poll')
 	expect(html).not.toContain('https://hooks.')

--- a/src/example-thread.node.test.ts
+++ b/src/example-thread.node.test.ts
@@ -78,7 +78,10 @@ test('example page is the view UI without join capabilities', async () => {
 	expect(html).toContain('M8 5.15v3.05')
 	expect(html).not.toContain('M2 8c2-2.4')
 	expect(html).not.toContain('M9.4 6A3.4')
-	expect(html).toContain('last polled')
+	expect(html).toMatch(/Offline · last polled .+ ago/)
+	expect(html).not.toContain(
+		`Offline · last polled ${exampleMembers[0].last_poll_at}`,
+	)
 	expect(html).toContain('Seen by relay via webhook')
 	expect(html).toContain('Seen by harbor via poll')
 	expect(html).not.toContain('https://hooks.')

--- a/src/thread-view-chat.node.test.ts
+++ b/src/thread-view-chat.node.test.ts
@@ -11,6 +11,7 @@ import {
 	agentIdenticonCells,
 	agentPresence,
 	agentStatusIcon,
+	formatPollAge,
 	contrastRatio,
 	isMineBubble,
 	mixHex,
@@ -141,6 +142,18 @@ test('status icons are centered bolt and clock, not wifi or refresh', () => {
 	expect(polling).not.toBe(none)
 })
 
+test('formatPollAge speaks relative English instead of an ISO stamp', () => {
+	const now = Date.parse('2026-08-26T12:00:00.000Z')
+	expect(formatPollAge('2026-08-26T11:59:55.000Z', now)).toBe('just now')
+	expect(formatPollAge('2026-08-26T11:59:40.000Z', now)).toBe('20 seconds ago')
+	expect(formatPollAge('2026-08-26T11:59:00.000Z', now)).toBe('1 minute ago')
+	expect(formatPollAge('2026-08-26T11:57:00.000Z', now)).toBe('3 minutes ago')
+	expect(formatPollAge('2026-08-26T10:00:00.000Z', now)).toBe('2 hours ago')
+	expect(formatPollAge('2026-08-24T12:00:00.000Z', now)).toBe('2 days ago')
+	expect(formatPollAge('2026-04-08T15:05:11.000Z', now)).toBe('4 months ago')
+	expect(formatPollAge('not-a-date', now)).toBe('not-a-date')
+})
+
 test('presence prefers webhook over polling and times out polls', () => {
 	const now = Date.parse('2026-08-26T12:00:00.000Z')
 	expect(agentPresence({ webhook: true, last_poll_at: null }, now)).toEqual({
@@ -153,19 +166,27 @@ test('presence prefers webhook over polling and times out polls', () => {
 			{ webhook: true, last_poll_at: '2026-08-26T11:59:50.000Z' },
 			now,
 		).label,
-	).toContain('Last polled 2026-08-26T11:59:50.000Z')
+	).toBe('Webhook · listening. Last polled 10 seconds ago.')
 	expect(
 		agentPresence(
 			{ webhook: false, last_poll_at: '2026-08-26T11:59:50.000Z' },
 			now,
 		),
-	).toMatchObject({ online: true, connection: 'polling' })
+	).toEqual({
+		online: true,
+		connection: 'polling',
+		label: 'Polling · last polled 10 seconds ago.',
+	})
 	expect(
 		agentPresence(
 			{ webhook: false, last_poll_at: '2026-08-26T11:58:00.000Z' },
 			now,
 		),
-	).toMatchObject({ online: false, connection: 'polling' })
+	).toEqual({
+		online: false,
+		connection: 'polling',
+		label: 'Offline · last polled 2 minutes ago.',
+	})
 	expect(agentPresence({ webhook: false, last_poll_at: null }, now)).toEqual({
 		online: false,
 		connection: 'none',

--- a/src/thread-view-chat.node.test.ts
+++ b/src/thread-view-chat.node.test.ts
@@ -151,6 +151,16 @@ test('formatPollAge speaks relative English instead of an ISO stamp', () => {
 	expect(formatPollAge('2026-08-26T10:00:00.000Z', now)).toBe('2 hours ago')
 	expect(formatPollAge('2026-08-24T12:00:00.000Z', now)).toBe('2 days ago')
 	expect(formatPollAge('2026-04-08T15:05:11.000Z', now)).toBe('4 months ago')
+	const dayMs = 24 * 60 * 60 * 1000
+	expect(formatPollAge(new Date(now - 360 * dayMs).toISOString(), now)).toBe(
+		'12 months ago',
+	)
+	expect(formatPollAge(new Date(now - 364 * dayMs).toISOString(), now)).toBe(
+		'12 months ago',
+	)
+	expect(formatPollAge(new Date(now - 365 * dayMs).toISOString(), now)).toBe(
+		'1 year ago',
+	)
 	expect(formatPollAge('not-a-date', now)).toBe('not-a-date')
 })
 

--- a/src/thread-view-chat.ts
+++ b/src/thread-view-chat.ts
@@ -94,6 +94,27 @@ export const AGENT_IDENTICON_SIZE = 32
 export const AGENT_IDENTICON_CELLS = 5
 export const AGENT_IDENTICON_UNIQUE_COLS = 3
 
+function pluralAge(count: number, unit: string) {
+	return `${count} ${unit}${count === 1 ? '' : 's'} ago`
+}
+
+export function formatPollAge(iso: string, now = Date.now()) {
+	const then = Date.parse(iso)
+	if (!Number.isFinite(then)) return iso
+	const seconds = Math.max(0, Math.floor((now - then) / 1000))
+	if (seconds < 10) return 'just now'
+	if (seconds < 60) return pluralAge(seconds, 'second')
+	const minutes = Math.floor(seconds / 60)
+	if (minutes < 60) return pluralAge(minutes, 'minute')
+	const hours = Math.floor(minutes / 60)
+	if (hours < 24) return pluralAge(hours, 'hour')
+	const days = Math.floor(hours / 24)
+	if (days < 30) return pluralAge(days, 'day')
+	const months = Math.floor(days / 30)
+	if (months < 12) return pluralAge(months, 'month')
+	return pluralAge(Math.floor(days / 365), 'year')
+}
+
 export type AgentLastSeenVia = 'poll' | 'webhook' | 'send'
 export type AgentConnectionKind = 'webhook' | 'polling' | 'none'
 
@@ -200,7 +221,7 @@ export function agentPresence(
 ): AgentPresence {
 	if (member.webhook) {
 		const poll = member.last_poll_at
-			? ` Last polled ${member.last_poll_at}.`
+			? ` Last polled ${formatPollAge(member.last_poll_at, now)}.`
 			: ''
 		return {
 			online: true,
@@ -211,12 +232,13 @@ export function agentPresence(
 	if (member.last_poll_at) {
 		const last = Date.parse(member.last_poll_at)
 		const online = Number.isFinite(last) && now - last <= AGENT_ONLINE_POLL_MS
+		const age = formatPollAge(member.last_poll_at, now)
 		return {
 			online,
 			connection: 'polling',
 			label: online
-				? `Polling · last polled ${member.last_poll_at}.`
-				: `Offline · last polled ${member.last_poll_at}.`,
+				? `Polling · last polled ${age}.`
+				: `Offline · last polled ${age}.`,
 		}
 	}
 	return {

--- a/src/thread-view-chat.ts
+++ b/src/thread-view-chat.ts
@@ -110,8 +110,7 @@ export function formatPollAge(iso: string, now = Date.now()) {
 	if (hours < 24) return pluralAge(hours, 'hour')
 	const days = Math.floor(hours / 24)
 	if (days < 30) return pluralAge(days, 'day')
-	const months = Math.floor(days / 30)
-	if (months < 12) return pluralAge(months, 'month')
+	if (days < 365) return pluralAge(Math.floor(days / 30), 'month')
 	return pluralAge(Math.floor(days / 365), 'year')
 }
 

--- a/src/thread-view-live.node.test.ts
+++ b/src/thread-view-live.node.test.ts
@@ -11,6 +11,7 @@ import {
 	threadViewLiveScript,
 	VIEW_POLL_DEFAULT_SECONDS,
 	VIEW_POLL_NEAR_BOTTOM_PX,
+	VIEW_PRESENCE_TICK_MS,
 	type ArchivedViewRoot,
 } from '#src/thread-view-live.ts'
 
@@ -71,6 +72,12 @@ test('live script prefers a socket and pins when already at the bottom', () => {
 	expect(script).toContain('agent-avatar')
 	expect(script).toContain('data-members')
 	expect(script).toContain('Webhook · listening.')
+	expect(script).toContain('function formatPollAge')
+	expect(script).toContain("return 'just now'")
+	expect(script).not.toContain("' · last polled ' + member.last_poll_at")
+	expect(script).toContain(`const presenceTickMs = ${VIEW_PRESENCE_TICK_MS}`)
+	expect(script).toContain('window.setInterval')
+	expect(script).toContain('window.clearInterval(presenceTimer)')
 	expect(script).toContain(JSON.stringify(agentStatusIcon('webhook')))
 	expect(script).toContain(JSON.stringify(agentStatusIcon('polling')))
 	expect(script).toContain(JSON.stringify(agentStatusIcon('none')))

--- a/src/thread-view-live.node.test.ts
+++ b/src/thread-view-live.node.test.ts
@@ -74,6 +74,8 @@ test('live script prefers a socket and pins when already at the bottom', () => {
 	expect(script).toContain('Webhook · listening.')
 	expect(script).toContain('function formatPollAge')
 	expect(script).toContain("return 'just now'")
+	expect(script).toContain('if (days < 365)')
+	expect(script).not.toContain('if (months < 12)')
 	expect(script).not.toContain("' · last polled ' + member.last_poll_at")
 	expect(script).toContain(`const presenceTickMs = ${VIEW_PRESENCE_TICK_MS}`)
 	expect(script).toContain('window.setInterval')

--- a/src/thread-view-live.ts
+++ b/src/thread-view-live.ts
@@ -9,6 +9,7 @@ import {
 
 export const VIEW_POLL_NEAR_BOTTOM_PX = 48
 export const VIEW_POLL_DEFAULT_SECONDS = 5
+export const VIEW_PRESENCE_TICK_MS = 15_000
 export const THREAD_VIEW_ARCHIVED_STAMP = 'Archived'
 export const THREAD_VIEW_ARCHIVED_INTRO =
 	'This thread is archived. It is read-only. Agents can no longer send or poll, and this page does not subscribe for updates.'
@@ -94,11 +95,13 @@ export function threadViewLiveScript() {
 		const identiconCells = ${AGENT_IDENTICON_CELLS}
 		const identiconUniqueCols = ${AGENT_IDENTICON_UNIQUE_COLS}
 		const onlinePollMs = ${AGENT_ONLINE_POLL_MS}
+		const presenceTickMs = ${VIEW_PRESENCE_TICK_MS}
 		let members = parseMembers(agents?.getAttribute('data-members'))
 		let socketOpen = false
 		let stopped = false
 		let liveSocket = null
 		let pollTimer = 0
+		let presenceTimer = 0
 		let pollGeneration = 0
 		function setLiveLabel(text) {
 			if (liveLabel) liveLabel.textContent = text
@@ -163,18 +166,36 @@ export function threadViewLiveScript() {
 			if (connection === 'polling') return ${JSON.stringify(agentStatusIcon('polling'))}
 			return ${JSON.stringify(agentStatusIcon('none'))}
 		}
+		function formatPollAge(iso, now) {
+			const then = Date.parse(iso)
+			if (!Number.isFinite(then)) return iso
+			const seconds = Math.max(0, Math.floor(((now ?? Date.now()) - then) / 1000))
+			if (seconds < 10) return 'just now'
+			const plural = (count, unit) => count + ' ' + unit + (count === 1 ? '' : 's') + ' ago'
+			if (seconds < 60) return plural(seconds, 'second')
+			const minutes = Math.floor(seconds / 60)
+			if (minutes < 60) return plural(minutes, 'minute')
+			const hours = Math.floor(minutes / 60)
+			if (hours < 24) return plural(hours, 'hour')
+			const days = Math.floor(hours / 24)
+			if (days < 30) return plural(days, 'day')
+			const months = Math.floor(days / 30)
+			if (months < 12) return plural(months, 'month')
+			return plural(Math.floor(days / 365), 'year')
+		}
 		function presenceFor(member) {
 			if (member?.webhook) {
-				const poll = member.last_poll_at ? ' Last polled ' + member.last_poll_at + '.' : ''
+				const poll = member.last_poll_at ? ' Last polled ' + formatPollAge(member.last_poll_at) + '.' : ''
 				return { online: true, connection: 'webhook', label: 'Webhook · listening.' + poll }
 			}
 			if (member?.last_poll_at) {
 				const last = Date.parse(member.last_poll_at)
 				const online = Number.isFinite(last) && Date.now() - last <= onlinePollMs
+				const age = formatPollAge(member.last_poll_at)
 				return {
 					online,
 					connection: 'polling',
-					label: (online ? 'Polling' : 'Offline') + ' · last polled ' + member.last_poll_at + '.',
+					label: (online ? 'Polling' : 'Offline') + ' · last polled ' + age + '.',
 				}
 			}
 			return { online: false, connection: 'none', label: 'Has not connected yet.' }
@@ -382,6 +403,7 @@ export function threadViewLiveScript() {
 			stopped = true
 			socketOpen = false
 			window.clearTimeout(pollTimer)
+			window.clearInterval(presenceTimer)
 			pollGeneration += 1
 			try { liveSocket?.close() } catch {}
 			liveSocket = null
@@ -478,5 +500,8 @@ export function threadViewLiveScript() {
 		}
 		pinToBottom()
 		connectLive()
+		presenceTimer = window.setInterval(() => {
+			if (!stopped) updateAvatars()
+		}, presenceTickMs)
 	</script>`
 }

--- a/src/thread-view-live.ts
+++ b/src/thread-view-live.ts
@@ -179,8 +179,7 @@ export function threadViewLiveScript() {
 			if (hours < 24) return plural(hours, 'hour')
 			const days = Math.floor(hours / 24)
 			if (days < 30) return plural(days, 'day')
-			const months = Math.floor(days / 30)
-			if (months < 12) return plural(months, 'month')
+			if (days < 365) return plural(Math.floor(days / 30), 'month')
 			return plural(Math.floor(days / 365), 'year')
 		}
 		function presenceFor(member) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Roster and bubble status badges now say how long ago an agent last polled (`last polled 2 minutes ago`) instead of the raw ISO timestamp.

Polling agents still go **Offline** when that last poll is older than 60 seconds. Webhook listeners stay online (they are not expected to poll). The live watch script refreshes those relative labels every 15 seconds so an open page ages from “just now” to “Offline” without a reload.

Bugbot caught a year-bucket edge: 360–364 days could render as `0 years ago`. Ages stay in months until a full 365 days, then `1 year ago`.

## Test plan
- Unit coverage for `formatPollAge` buckets (including 360 / 364 / 365 days) and presence labels
- Live script embeds the same relative formatter and a presence tick
- Example thread (harbor’s April last-poll) renders `Offline · last polled … ago` without an ISO stamp in the visible label
- `npm run validate` passed locally before the year-bucket follow-up; targeted tests passed after it
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-789aea37-32f0-4a2e-9e9d-f5b53d77ae0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-789aea37-32f0-4a2e-9e9d-f5b53d77ae0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polling and webhook activity now display human-readable relative times, such as “10 seconds ago.”
  * Live thread views refresh presence indicators automatically every 15 seconds.
* **Bug Fixes**
  * Improved offline status messaging by replacing raw timestamps with relative “ago” labels.
  * Invalid timestamps safely fall back to the original timestamp format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->