### PR TITLE
Collapse the Threads create prompt and feature MCP

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -270,6 +270,8 @@ main.thread-page { width: min(720px, calc(100% - 2rem)); }
 .thread-prompts > summary { cursor: pointer; font-family: "IBM Plex Mono", monospace; font-size: .85rem; color: var(--muted); }
 .thread-prompts[open] > summary { margin-bottom: .4rem; color: var(--ink); }
 .thread-prompts .card { margin: .75rem 0 0; }
+.mcp-connect-url { margin: .85rem 0 .35rem; align-items: center; }
+.mcp-connect-url code { font-size: .95rem; }
 .chat { display: flex; flex-direction: column; gap: .75rem; margin: 1.2rem 0 2rem; min-height: 12rem; max-height: min(70vh, 44rem); overflow-y: auto; overflow-anchor: none; padding: .15rem .25rem .15rem 0; }
 .thread-agents { margin: .35rem 0 0; }
 .agent-roster { display: flex; flex-wrap: wrap; gap: .65rem 1rem; list-style: none; margin: .55rem 0 0; padding: 0; }
@@ -407,6 +409,23 @@ ${createThreadAftermath({
 })}`
 }
 
+export function mcpConnectCard(input: { baseUrl: string; login?: string }) {
+	const url = `${input.baseUrl.replace(/\/$/, '')}/mcp`
+	const who = input.login?.trim()
+		? ` as @${escapeHtml(input.login.trim())}`
+		: ''
+	return `<div class="card mcp-connect" data-mcp-connect>
+		<h3>Connect MCP</h3>
+		<p>Add this server to the agent you already use. After you approve OAuth${who}, it can create threads on your account — no prompt to copy.</p>
+		<div class="row mcp-connect-url">
+			<code id="mcp-url">${escapeHtml(url)}</code>
+			<button type="button" data-copy="mcp-url">Copy MCP URL</button>
+			<span class="tiny" data-copied hidden>Copied.</span>
+		</div>
+		<p class="tiny">Included with your account. Tools include <code>create_thread</code>. <a href="/mcp">How MCP works</a>.</p>
+	</div>`
+}
+
 export function promptCard(input: {
 	id: string
 	title: string
@@ -423,6 +442,16 @@ export function promptCard(input: {
 			<span class="tiny" data-copied hidden>Copied.</span>
 		</div>
 	</div>`
+}
+
+export function promptCardDetails(
+	input: Parameters<typeof promptCard>[0] & { summary: string },
+) {
+	const { summary, ...card } = input
+	return `<details class="thread-prompts" data-create-thread-prompt>
+		<summary>${escapeHtml(summary)}</summary>
+		${promptCard(card)}
+	</details>`
 }
 
 export function agentPromptBox(input: { id: string; prompt: string }) {

--- a/src/pages.node.test.ts
+++ b/src/pages.node.test.ts
@@ -29,8 +29,19 @@ test('signed-in account is threads, not agent tokens', async () => {
 	expect(html).not.toContain('Create agent token')
 	expect(html).not.toContain('live agent tokens')
 	expect(html).not.toContain('New agent token')
-	expect(html).toContain('included with a signed-in account')
+	expect(html).toContain('data-mcp-connect')
+	expect(html).toContain('Connect MCP')
+	expect(html).toContain('id="mcp-url"')
+	expect(html).toContain('https://kody.exchange/mcp')
+	expect(html).toContain('Copy MCP URL')
+	expect(html).toContain('no prompt to copy')
+	expect(html).toContain('href="/mcp"')
 	expect(html).toContain('Create a thread from your agent')
+	expect(html).toContain('Create a thread from a copied prompt')
+	expect(html).toContain('class="thread-prompts" data-create-thread-prompt')
+	expect(html).not.toMatch(
+		/<details class="thread-prompts" data-create-thread-prompt[^>]*\bopen\b/,
+	)
 	expect(html).toContain('Copy create-a-thread prompt')
 	expect(html).toContain('id="create-thread-prompt"')
 	expect(html).toContain('already signed in as @kent')
@@ -38,6 +49,8 @@ test('signed-in account is threads, not agent tokens', async () => {
 	expect(html).toContain('create_thread')
 	expect(html).toContain('POST https://kody.exchange/api/threads')
 	expect(html).toContain('data-copy="create-thread-prompt"')
+	expect(html).toContain('data-copy="mcp-url"')
+	expect(html).not.toContain('included with a signed-in account')
 })
 
 test('signed-in homepage shows the account create prompt, not guest /v1', async () => {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -33,7 +33,9 @@ import {
 	layout,
 	pricingPage,
 	privacyPage,
+	mcpConnectCard,
 	promptCard,
+	promptCardDetails,
 	safetyNavLabel,
 	safetyPath,
 	termsPage,
@@ -519,12 +521,16 @@ async function accountPage(
 	return `
 	<h1>Threads</h1>
 	<p class="lede">@${escapeHtml(user.login)} · ${escapeHtml(plan.label)} · ${liveThreads}/${plan.threads} live</p>
-	<p>A thread is a room. You create it here, then we give you two prompts to copy. You do not invent tokens.</p>
-	<p class="tiny">OAuth API and MCP are included with a signed-in account. Point integrations at <code>${escapeHtml(appBaseUrl(env, request))}/mcp</code> and approve the prompt. Guest threads still work over plain <code>/v1</code> with no account.</p>
-	${promptCard({
+	<p>A thread is a room. Connect MCP so your agent can create one, or create it here and copy the two prompts. You do not invent tokens.</p>
+	${mcpConnectCard({
+		baseUrl: appBaseUrl(env, request),
+		login: user.login,
+	})}
+	${promptCardDetails({
 		id: 'create-thread-prompt',
+		summary: 'Create a thread from a copied prompt',
 		title: 'Create a thread from your agent',
-		hint: 'Copy this into the agent you already use. It asks for a purpose and a display name, then uses MCP or the OAuth API — not the guest room.',
+		hint: 'Copy this into an agent that cannot connect MCP. It asks for a purpose and a display name, then uses MCP or the OAuth API — not the guest room.',
 		prompt: homepagePrompt(appBaseUrl(env, request), {
 			signedIn: true,
 			login: user.login,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The account Threads page led with a full-height create-a-thread prompt. That prompt now lives in a closed `<details>` like host/guest prompts.

MCP is the first path: a card with the server URL, a copy button, and copy that connecting it lets an agent create threads on the account without pasting the prompt.

## Test plan
- Account page tests lock `data-mcp-connect`, the MCP URL/copy control, and a closed `data-create-thread-prompt` details
- The long prompt text and copy button remain inside the details
- `npm run validate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-789aea37-32f0-4a2e-9e9d-f5b53d77ae0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-789aea37-32f0-4a2e-9e9d-f5b53d77ae0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an MCP connection card with a copyable connection URL and copy button.
  - Added a link to the MCP connection page from the signed-in account area.
  - Added collapsible thread-creation guidance.

- **Updates**
  - Updated account guidance to help agents connect through MCP or the OAuth API.
  - Refined messaging for agents that cannot connect to MCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->