### PR TITLE
Filter bare D1 internal-error Sentry noise

### DIFF
--- a/src/sentry-options.node.test.ts
+++ b/src/sentry-options.node.test.ts
@@ -121,6 +121,32 @@ test('drops retryable D1 platform noise and keeps real errors', () => {
 			),
 		),
 	).toBeNull()
+	expect(
+		filterSentryEvent(
+			errorEvent(
+				'D1_ERROR: internal error in D1 DB storage caused object to be reset; reference = abc123',
+			),
+		),
+	).toBeNull()
+	expect(
+		filterSentryEvent(
+			errorEvent('internal error; reference = 4g5mg5npu939v89t62h451km'),
+		),
+	).toBeNull()
+	expect(
+		filterSentryEvent(
+			errorEvent(
+				'D1_ERROR: internal error; reference = 4g5mg5npu939v89t62h451km',
+			),
+		),
+	).toBeNull()
+	expect(
+		filterSentryEvent(
+			errorEvent(
+				'Error: D1_ERROR: internal error; reference = 4g5mg5npu939v89t62h451km',
+			),
+		),
+	).toBeNull()
 	expect(filterSentryEvent(errorEvent('Network connection lost'))).toBeNull()
 	expect(
 		filterSentryEvent(errorEvent(d1StorageOperationTimeoutResetMessage)),
@@ -142,6 +168,8 @@ test('drops retryable D1 platform noise and keeps real errors', () => {
 	).toBeNull()
 	const kept = errorEvent('thread create failed')
 	expect(filterSentryEvent(kept)).toBe(kept)
+	const keptIncompleteInternal = errorEvent('D1_ERROR: internal error')
+	expect(filterSentryEvent(keptIncompleteInternal)).toBe(keptIncompleteInternal)
 })
 
 test('drops localhost request URLs so wrangler cannot email production', () => {

--- a/src/sentry-options.ts
+++ b/src/sentry-options.ts
@@ -64,8 +64,11 @@ export function isRetryableD1PlatformMessage(message: string) {
 		'',
 	)
 	if (normalized.includes(d1StorageTimeoutStem)) return true
-	return /^internal error in D1 DB storage caused object to be reset;\s*reference\s*=\s*[A-Za-z0-9]+$/i.test(
-		normalized,
+	// Cloudflare wraps platform blips as `D1_ERROR: …` (and sometimes `Error: D1_ERROR: …`).
+	const withoutD1Prefix = normalized.replace(/^D1_ERROR:\s*/i, '')
+	// Bare `internal error; reference = …` and the longer storage-reset form.
+	return /^internal error(?: in D1 DB storage caused object to be reset)?;\s*reference\s*=\s*[A-Za-z0-9]+$/i.test(
+		withoutD1Prefix,
 	)
 }
 

--- a/src/threads.node.test.ts
+++ b/src/threads.node.test.ts
@@ -641,6 +641,7 @@ test('a successful peer webhook records a read receipt', async () => {
 		threadId: created.thread.id,
 		agent: joined.agent,
 		url: 'https://example.test/hook',
+		now: now + 1_000,
 	})
 	if (!webhook.ok) throw new Error(webhook.error)
 	const sent = await sendMessage({
@@ -699,6 +700,7 @@ test('one webhook URL shared by two members receipts both', async () => {
 		threadId: created.thread.id,
 		agent: joined.agent,
 		url: 'https://example.test/shared',
+		now: now + 1_000,
 	})
 	if (!webhook.ok) throw new Error(webhook.error)
 	const sent = await sendMessage({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloudflare D1 emitted a transient `D1_ERROR: internal error; reference = …` during `listMessagesForView` → `loadThreadMessages` (GET `/t/*/messages`). Breadcrumbs show earlier D1 queries on the same request succeeded — platform flakiness, not an app bug in the messages query.

Seer’s “add retry everywhere” path is larger than this class has been handled before. Matching PR #55, extended the existing `isRetryableD1PlatformMessage` / `beforeSend` filter so this signature (bare, `D1_ERROR:`, and `Error: D1_ERROR:`) is dropped like other retryable D1 platform noise. Incomplete `internal error` without a Cloudflare reference id is still reported.

Also passed frozen `now` into `setWebhook` in two guest webhook tests so they do not expire against wall clock (24h guest retention).

## Risk

Low — narrow `beforeSend` filter + test clock fix; no auth/DB behavior change.

## Status

- Squash-merged as `a6f5cd7256574fbbe1797bacee219cd9ba2f9827`
- Production deploy green; `GET /health` commit matches
- Sentry KODY-EXCHANGE-4 ignored (filtered)

## Test plan

- [x] `npm run validate`
- [x] CI green on this PR
- [x] After merge: ignore Sentry issue KODY-EXCHANGE-4

Sentry: https://kent-c-dodds-tech-llc.sentry.io/issues/7696109987/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa54c33a-ab02-4ebd-af10-8543c588d928?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa54c33a-ab02-4ebd-af10-8543c588d928&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Cloudflare D1 internal-error messages, including common prefixes and reference details.
  - Prevented incomplete or unrecognized D1 error messages from being incorrectly filtered.
  - Improved webhook timing consistency in related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->