### PR TITLE
Route ship-pr Bugbot triggers through kody:@kentcdodds/bugbot

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -29,7 +29,14 @@ explicitly.
 ## AI reviewers
 
 Prefer **Cursor Bugbot** (`Cursor Bugbot` check / `cursor[bot]` review comments).
-Trigger with `bugbot run` or `@cursor review` on the PR if it has not started.
+Never comment `bugbot run` or `cursor review` yourself — including via `gh` or
+GitHub `request` as kody-bot. Trigger with `kody:@kentcdodds/bugbot` using
+`{ prUrl }` or `{ owner, repo, prNumber }`. Do not pass a GitHub account.
+
+```javascript
+import triggerBugbot from 'kody:@kentcdodds/bugbot'
+await triggerBugbot({ prUrl })
+```
 
 **CodeRabbit:** if it is rate-limited, errored, or otherwise unavailable, **do not
 wait** on it for low/medium risk — proceed with Bugbot + CI. Only wait on


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
kody-bot is not authorized to trigger Cursor Bugbot. A comment of `bugbot run` from kody-bot is skipped (`Unable to authenticate your request`).

This updates the ship-pr skill so agents call `kody:@kentcdodds/bugbot` (posted as kentcdodds) instead of commenting `bugbot run` or `cursor review` themselves.

- Prefer Cursor Bugbot (same check / `cursor[bot]` comments)
- Never comment `bugbot run` or `cursor review` via `gh` or GitHub `request` as kody-bot
- Trigger with `{ prUrl }` or `{ owner, repo, prNumber }`; do not pass a GitHub account

CodeRabbit guidance, the loop (`account: 'kent'` on set-review-status), merge policy, and the rest of the skill are unchanged.

Do not merge. Do not comment `bugbot run` on this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4d7174-9711-4c2f-bc41-3df1a268a5fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4d7174-9711-4c2f-bc41-3df1a268a5fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review guidance to use the supported Bugbot integration workflow.
  * Added an example showing how to trigger automated pull request reviews with the required identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->