### PR TITLE
Fix D1_TYPE_ERROR when owned thread create gets undefined user.id

### DIFF
--- a/src/admin.node.test.ts
+++ b/src/admin.node.test.ts
@@ -10,7 +10,10 @@ import {
 
 test('admin insights count users, rooms, and messages without bodies', async () => {
 	const env = createTestEnv()
-	const now = Date.UTC(2026, 7, 16, 18, 0, 0)
+	// Wall-clock "this month" usage is recorded at send time; keep insights `now`
+	// in the same UTC month so thisMonthGuest is not calendar-flaky.
+	const now = Date.now()
+	const day = new Date(now).toISOString().slice(0, 10)
 	await createSignedInUser(env, {
 		id: 'usr_op',
 		github_id: '99',
@@ -113,7 +116,7 @@ test('admin insights count users, rooms, and messages without bodies', async () 
 	)
 	expect(JSON.stringify(insights)).not.toContain('203.0.113.9')
 	expect(JSON.stringify(insights)).not.toContain('kx_live_')
-	expect(insights.dailyMessages[0]?.day).toBe('2026-08-16')
+	expect(insights.dailyMessages[0]?.day).toBe(day)
 	expect(insights.dailyMessages).toHaveLength(14)
 })
 

--- a/src/db.node.test.ts
+++ b/src/db.node.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'vitest'
+import { all, d1BindParams, first, run } from '#src/db.ts'
+import { createTestEnv } from '#src/test-support.ts'
+
+test('d1BindParams turns undefined into null for Cloudflare D1', () => {
+	expect(d1BindParams(['ok', undefined, 1, null])).toEqual([
+		'ok',
+		null,
+		1,
+		null,
+	])
+})
+
+test('run/first/all accept undefined binds without throwing', async () => {
+	const env = createTestEnv()
+	await run(
+		env.DB,
+		`INSERT INTO threads (id, owner_user_id, purpose, thread_secret, view_token_hash, join_token_hash, webhook_url, created_at, expires_at, creator_ip)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		'th_bind',
+		undefined,
+		null,
+		'secret',
+		'view',
+		'join',
+		undefined,
+		1,
+		2,
+		'unknown',
+	)
+	const row = await first<{ owner_user_id: string | null }>(
+		env.DB,
+		'SELECT owner_user_id FROM threads WHERE id = ?',
+		'th_bind',
+	)
+	expect(row?.owner_user_id).toBeNull()
+	const rows = await all<{ id: string }>(
+		env.DB,
+		'SELECT id FROM threads WHERE owner_user_id IS ?',
+		undefined,
+	)
+	expect(rows.map((r) => r.id)).toContain('th_bind')
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,3 +1,12 @@
+/**
+ * Cloudflare D1 rejects `undefined` binds with D1_TYPE_ERROR. Absent SQL
+ * values must be `null`. Coerce at the boundary so call sites cannot crash
+ * the Worker with a platform type error.
+ */
+export function d1BindParams(params: Array<unknown>) {
+	return params.map((value) => (value === undefined ? null : value))
+}
+
 export async function first<T>(
 	db: D1Database,
 	sql: string,
@@ -5,7 +14,7 @@ export async function first<T>(
 ) {
 	return db
 		.prepare(sql)
-		.bind(...params)
+		.bind(...d1BindParams(params))
 		.first<T>()
 }
 
@@ -16,7 +25,7 @@ export async function all<T>(
 ) {
 	const result = await db
 		.prepare(sql)
-		.bind(...params)
+		.bind(...d1BindParams(params))
 		.all<T>()
 	return result.results
 }
@@ -28,7 +37,7 @@ export async function run(
 ) {
 	return db
 		.prepare(sql)
-		.bind(...params)
+		.bind(...d1BindParams(params))
 		.run()
 }
 

--- a/src/oauth-user.ts
+++ b/src/oauth-user.ts
@@ -159,7 +159,15 @@ function bearer(request: Request) {
 }
 
 export async function resolveOAuthUser(request: Request, env: AppEnv) {
-	if (env.OAUTH_USER) return env.OAUTH_USER
+	if (env.OAUTH_USER) {
+		if (
+			typeof env.OAUTH_USER.id !== 'string' ||
+			env.OAUTH_USER.id.length === 0
+		) {
+			return null
+		}
+		return env.OAUTH_USER
+	}
 	const token = bearer(request)
 	const helpers = env.OAUTH_PROVIDER
 	if (!token || !helpers) return null

--- a/src/threads.node.test.ts
+++ b/src/threads.node.test.ts
@@ -964,3 +964,21 @@ test('deleteThread removes members and messages; missing threads 404', async () 
 	})
 	expect(missing).toMatchObject({ ok: false, code: 'thread_not_found' })
 })
+
+test('createThread treats undefined ownerUserId as a guest create', async () => {
+	const env = createTestEnv()
+	const created = await createThread({
+		db: env.DB,
+		baseUrl: 'https://kody.exchange',
+		// Runtime hole Seer found: typed as string | null but undefined arrives.
+		ownerUserId: undefined as unknown as null,
+		creatorIp: '203.0.113.9',
+		purpose: 'undefined-owner',
+		name: 'cursor',
+		now: Date.parse('2026-09-01T00:00:00Z'),
+	})
+	if (!created.ok) throw new Error(created.error)
+	expect(created.plan).toBe('guest')
+	expect(created.thread.owner_user_id).toBeNull()
+	expect(created.thread.creator_ip).toBe('203.0.113.9')
+})

--- a/src/threads.node.test.ts
+++ b/src/threads.node.test.ts
@@ -858,7 +858,7 @@ test('owner can keep a thread forever; it still counts as live and survives purg
 		now: now + 6000,
 	})
 	if (!third.ok) throw new Error(third.error)
-	expect(await countOwnedThreads(env.DB, 'usr_keep')).toBe(3)
+	expect(await countOwnedThreads(env.DB, 'usr_keep', now + 6000)).toBe(3)
 	const fourth = await createThread({
 		db: env.DB,
 		baseUrl: 'https://kody.exchange',

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -581,7 +581,9 @@ export async function createThread(input: {
 	  }>
 > {
 	const now = input.now ?? Date.now()
-	const planName = await planForOwner(input.db, input.ownerUserId)
+	// D1 rejects undefined; callers may pass a missing id as undefined.
+	const ownerUserId = input.ownerUserId ?? null
+	const planName = await planForOwner(input.db, ownerUserId)
 	const plan = getPlan(planName)
 	const webhook =
 		input.webhookUrl === undefined || input.webhookUrl === null
@@ -589,9 +591,9 @@ export async function createThread(input: {
 			: parseWebhookUrl(input.webhookUrl)
 	if (!webhook.ok) return webhook
 
-	const creatorIp = input.ownerUserId ? null : sanitizeIp(input.creatorIp)
-	if (input.ownerUserId) {
-		const owned = await countOwnedThreads(input.db, input.ownerUserId)
+	const creatorIp = ownerUserId ? null : sanitizeIp(input.creatorIp)
+	if (ownerUserId) {
+		const owned = await countOwnedThreads(input.db, ownerUserId)
 		if (owned >= plan.threads) {
 			return fail(
 				402,
@@ -635,7 +637,7 @@ export async function createThread(input: {
 		`INSERT INTO threads (id, owner_user_id, purpose, thread_secret, view_token_hash, join_token_hash, webhook_url, created_at, expires_at, creator_ip)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		threadId,
-		input.ownerUserId,
+		ownerUserId,
 		purpose,
 		threadSecret,
 		await sha256Hex(viewToken),
@@ -650,7 +652,7 @@ export async function createThread(input: {
 		`INSERT INTO agents (id, user_id, thread_id, name, token_hash, created_at, revoked_at)
 		 VALUES (?, ?, ?, ?, ?, ?, NULL)`,
 		agentId,
-		input.ownerUserId,
+		ownerUserId,
 		threadId,
 		name,
 		await sha256Hex(token),

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -387,12 +387,16 @@ export async function countGuestThreadsForIp(
 	return row?.n ?? 0
 }
 
-export async function countOwnedThreads(db: D1Database, userId: string) {
+export async function countOwnedThreads(
+	db: D1Database,
+	userId: string,
+	now = Date.now(),
+) {
 	const row = await first<{ n: number }>(
 		db,
 		`SELECT COUNT(*) AS n FROM threads WHERE owner_user_id = ? AND ${sqlThreadLive()}`,
 		userId,
-		Date.now(),
+		now,
 	)
 	return row?.n ?? 0
 }
@@ -593,7 +597,7 @@ export async function createThread(input: {
 
 	const creatorIp = ownerUserId ? null : sanitizeIp(input.creatorIp)
 	if (ownerUserId) {
-		const owned = await countOwnedThreads(input.db, ownerUserId)
+		const owned = await countOwnedThreads(input.db, ownerUserId, now)
 		if (owned >= plan.threads) {
 			return fail(
 				402,

--- a/src/user-api.node.test.ts
+++ b/src/user-api.node.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'vitest'
+import { createOwnedThread } from '#src/user-api.ts'
+import {
+	createSignedInUser,
+	createTestEnv,
+	request,
+} from '#src/test-support.ts'
+import { type UserRow } from '#src/threads.ts'
+
+test('createOwnedThread rejects a user without an id instead of D1_TYPE_ERROR', async () => {
+	const env = createTestEnv()
+	const broken = {
+		id: undefined,
+		github_id: '9',
+		login: 'ghost',
+		name: null,
+		avatar_url: null,
+		email: null,
+		plan: 'free',
+		stripe_customer_id: null,
+		stripe_subscription_id: null,
+		created_at: 1,
+	} as unknown as UserRow
+
+	const response = await createOwnedThread(
+		request('/api/threads', { method: 'POST' }),
+		env,
+		broken,
+		{ purpose: 'should-not-insert' },
+	)
+	expect(response.status).toBe(401)
+	expect(await response.json()).toMatchObject({
+		ok: false,
+		code: 'invalid_token',
+	})
+})
+
+test('createOwnedThread creates an owned thread for a signed-in user', async () => {
+	const env = createTestEnv()
+	const { user } = await createSignedInUser(env)
+	const response = await createOwnedThread(
+		request('/api/threads', { method: 'POST' }),
+		env,
+		user,
+		{ purpose: 'owned', name: 'cursor' },
+	)
+	expect(response.status).toBe(200)
+	const body = (await response.json()) as {
+		ok: boolean
+		thread: { id: string }
+		plan: string
+	}
+	expect(body).toMatchObject({ ok: true, plan: 'free' })
+	expect(body.thread.id).toMatch(/^th_/)
+})

--- a/src/user-api.ts
+++ b/src/user-api.ts
@@ -109,6 +109,19 @@ export async function createOwnedThread(
 	input: { purpose?: unknown; name?: unknown; webhook_url?: unknown },
 	ctx?: ExecutionContext,
 ) {
+	// Owned creates must never fall through to the guest path: a missing
+	// user.id is falsy, so createThread would bind undefined/null as a guest
+	// insert and (before D1 null-coercion) throw D1_TYPE_ERROR.
+	if (typeof user.id !== 'string' || user.id.length === 0) {
+		return json(
+			{
+				ok: false,
+				error: 'Signed-in user is missing an id. Re-authorize and try again.',
+				code: 'invalid_token',
+			},
+			401,
+		)
+	}
 	const created = await createThread({
 		db: env.DB,
 		baseUrl: appBaseUrl(env, request),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -26,9 +26,20 @@ import {
 import { purgeExpired } from '#src/threads.ts'
 import { handleUserApi } from '#src/user-api.ts'
 
+function isUsableOAuthUser(
+	user: Awaited<ReturnType<typeof userFromGrantProps>>,
+) {
+	return typeof user?.id === 'string' && user.id.length > 0
+}
+
 async function userFromApiContext(env: AppEnv, ctx: ExecutionContext) {
-	if (env.OAUTH_USER) return env.OAUTH_USER
-	return userFromGrantProps(env, ctx.props as OAuthGrantProps | undefined)
+	const user = env.OAUTH_USER
+		? env.OAUTH_USER
+		: await userFromGrantProps(env, ctx.props as OAuthGrantProps | undefined)
+	// Fail closed: a props/test user without id must not reach createOwnedThread
+	// (falsy id takes the guest create path and historically D1_TYPE_ERRORed).
+	if (!isUsableOAuthUser(user)) return null
+	return user
 }
 
 function unknownUserResponse() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-EXCHANGE-5](https://kent-c-dodds-tech-llc.sentry.io/issues/7703820124/): `D1_TYPE_ERROR: Type 'undefined' not supported for value 'undefined'` on `POST /api/threads` → `createOwnedThread` → `createThread`.

Seer was right: a falsy/`undefined` `user.id` took the guest create path, then the threads INSERT bound `undefined` for `owner_user_id` and D1 rejected it.

## Fix

- Coerce `undefined` → `null` in `db.ts` bind helpers (eliminates this D1 error class).
- Fail closed when the OAuth/`OAUTH_USER` row has no `id` (`worker.ts`, `oauth-user.ts`).
- `createOwnedThread` returns `401 invalid_token` instead of falling through to guest create.
- `createThread` normalizes `ownerUserId ?? null` and passes frozen `now` into `countOwnedThreads` (also unblocks calendar-flaky keep/admin tests once wall clock passed the August fixtures).

## Test plan

- [x] `npm run validate`
- [x] New tests: `d1BindParams`, `createOwnedThread` without id, `createThread` with `undefined` owner
- [x] Calendar fixes for keep-forever + admin this-month guest assertions

Risk: **low** — isolated null-coercion + auth fail-closed; no schema/auth model change beyond rejecting malformed users.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56da8bae-3e4e-4e19-b96a-65cc178071ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56da8bae-3e4e-4e19-b96a-65cc178071ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or incomplete sign-in information, returning an appropriate authentication error instead of failing unexpectedly.
  * Guest thread creation now consistently preserves guest status and associated request details.
  * Improved database compatibility when optional values are missing.
  * Fixed time-dependent insights and thread-limit behavior to remain accurate across calendar periods.

* **Tests**
  * Expanded coverage for authentication, guest and owned thread creation, database operations, and date-sensitive insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->